### PR TITLE
fix issue #175, add line numbers and copy function to codeblock

### DIFF
--- a/src/components/Code.js
+++ b/src/components/Code.js
@@ -1,112 +1,112 @@
-import { makeStyles } from "@material-ui/core/styles";
-import React from "react";
-import IconButton from "@material-ui/core/IconButton";
-import FileCopyIcon from "@material-ui/icons/FileCopy";
-import Snackbar from "@material-ui/core/Snackbar";
+import { makeStyles } from '@material-ui/core/styles'
+import React from 'react'
+import IconButton from '@material-ui/core/IconButton'
+import FileCopyIcon from '@material-ui/icons/FileCopy'
+import Snackbar from '@material-ui/core/Snackbar'
 
-const useStyles = makeStyles((theme) => ({
-  lineWrapper: { display: "flex" },
+const useStyles = makeStyles(() => ({
+  lineWrapper: { display: 'flex' },
   lineNumber: {
     /* background: rgba(255, 255, 255, 0.1); */
-    width: "1.5rem",
+    width: '1.5rem',
     opacity: 0.6,
-    "text-align": "right",
-    "user-select": "none",
+    'text-align': 'right',
+    'user-select': 'none',
   },
   lineContents: {
-    flex: "1 0 auto",
-    "white-space": "pre",
+    flex: '1 0 auto',
+    'white-space': 'pre',
   },
-}));
+}))
 
 /*
  * @source https://github.com/gatsbyjs/gatsby/blob/561d33e2e491d3971cb2a404eec9705a5a493602/www/src/utils/copy-to-clipboard.js
  */
 const copyToClipboard = (str) => {
-  const clipboard = window.navigator.clipboard;
+  const clipboard = window.navigator.clipboard
   /*
    * fallback to older browsers (including Safari)
    * if clipboard API not supported
    */
-  if (!clipboard || typeof clipboard.writeText !== `function`) {
-    const textarea = document.createElement(`textarea`);
-    textarea.value = str;
-    textarea.setAttribute(`readonly`, true);
-    textarea.setAttribute(`contenteditable`, true);
-    textarea.style.position = `absolute`;
-    textarea.style.left = `-9999px`;
-    document.body.appendChild(textarea);
-    textarea.select();
-    const range = document.createRange();
-    const sel = window.getSelection();
-    sel.removeAllRanges();
-    sel.addRange(range);
-    textarea.setSelectionRange(0, textarea.value.length);
-    document.execCommand(`copy`);
-    document.body.removeChild(textarea);
+  if (!clipboard || typeof clipboard.writeText !== 'function') {
+    const textarea = document.createElement('textarea')
+    textarea.value = str
+    textarea.setAttribute('readonly', true)
+    textarea.setAttribute('contenteditable', true)
+    textarea.style.position = 'absolute'
+    textarea.style.left = '-9999px'
+    document.body.appendChild(textarea)
+    textarea.select()
+    const range = document.createRange()
+    const sel = window.getSelection()
+    sel.removeAllRanges()
+    sel.addRange(range)
+    textarea.setSelectionRange(0, textarea.value.length)
+    document.execCommand('copy')
+    document.body.removeChild(textarea)
 
-    return Promise.resolve(true);
+    return Promise.resolve(true)
   }
 
-  return clipboard.writeText(str);
-};
+  return clipboard.writeText(str)
+}
 
-export default function Code(codeBlocks) {
-  return (props) => {
-    const classes = useStyles();
-    const index = Number(props["data-index"]);
-    const codeBlock = codeBlocks[index];
+export default function Code (codeBlocks) {
+  const classes = useStyles()
+  return function codeRender (props) {
+    const index = Number(props['data-index'])
+    const codeBlock = codeBlocks[index]
     const CopySnackbar = () => {
-      const [open, setOpen] = React.useState(false);
+      const [open, setOpen] = React.useState(false)
 
       const handleClick = () => {
-        copyToClipboard(codeBlock.text);
-        setOpen(true);
-      };
+        copyToClipboard(codeBlock.text)
+        setOpen(true)
+      }
 
       const handleClose = (event, reason) => {
-        if (reason === "clickaway") {
-          return;
+        if (reason === 'clickaway') {
+          return
         }
-        setOpen(false);
-      };
+        setOpen(false)
+      }
 
       return (
-        <div 
-        style={{
-            position: "absolute",
-            right: "0.25em",
+        <div
+          style={{
+            position: 'absolute',
+            right: '0.25em',
             border: 0,
-            margin: "0.25px", 
-        }}>
+            margin: '0.25px',
+          }}>
           <IconButton
-            style={{backgroundColor: 'black', color: 'white'}}
-            size="small"
-            aria-label="copy"
+            style={{ backgroundColor: 'black', color: 'white' }}
+            size='small'
+            aria-label='copy'
             onClick={handleClick}
           >
-            <FileCopyIcon fontSize="small" />
+            <FileCopyIcon fontSize='small' />
           </IconButton>
           <Snackbar
             anchorOrigin={{
-              vertical: "bottom",
-              horizontal: "center",
+              vertical: 'bottom',
+              horizontal: 'center',
             }}
             open={open}
             autoHideDuration={1000}
             onClose={handleClose}
-            message="源代码已复制"
+            message='源代码已复制'
           />
         </div>
-      );
-    };
+      )
+    }
     if (codeBlock && codeBlock.tokenizedLines) {
-      console.log(codeBlock.text);
+      console.log(codeBlock.text)
       return (
         <div>
           <div
             className={codeBlock.preClassName}
-            style={{ position: "relative" }}
+            style={{ position: 'relative' }}
           >
             <CopySnackbar />
             <code className={codeBlock.codeClassName}>
@@ -122,8 +122,8 @@ export default function Code(codeBlocks) {
             </code>
           </div>
         </div>
-      );
+      )
     }
-    return <pre {...props}></pre>;
-  };
+    return <pre {...props}></pre>
+  }
 }

--- a/src/components/Code.js
+++ b/src/components/Code.js
@@ -101,29 +101,26 @@ export default function Code (codeBlocks) {
       )
     }
     if (codeBlock && codeBlock.tokenizedLines) {
-      console.log(codeBlock.text)
       return (
-        <div>
-          <div
-            className={codeBlock.preClassName}
-            style={{ position: 'relative' }}
-          >
-            <CopySnackbar />
-            <code className={codeBlock.codeClassName}>
-              {codeBlock.tokenizedLines.map(({ html }, i) => (
-                <div className={classes.lineWrapper} key={i}>
-                  <div className={classes.lineNumber}>{i}</div>
-                  <div
-                    className={classes.lineContents}
-                    dangerouslySetInnerHTML={{ __html: html }}
-                  />
-                </div>
-              ))}
-            </code>
-          </div>
+        <div
+          className={codeBlock.preClassName}
+          style={{ position: 'relative' }}
+        >
+          <CopySnackbar />
+          <code className={codeBlock.codeClassName}>
+            {codeBlock.tokenizedLines.map(({ html }, i) => (
+              <div className={classes.lineWrapper} key={i}>
+                <div className={classes.lineNumber}>{i}</div>
+                <div
+                  className={classes.lineContents}
+                  dangerouslySetInnerHTML={{ __html: html }}
+                />
+              </div>
+            ))}
+          </code>
         </div>
       )
     }
-    return <pre {...props}></pre>
+    return <pre {...props}/>
   }
 }

--- a/src/components/Code.js
+++ b/src/components/Code.js
@@ -1,10 +1,33 @@
 import { makeStyles } from '@material-ui/core/styles'
 import React from 'react'
 import IconButton from '@material-ui/core/IconButton'
-import FileCopyIcon from '@material-ui/icons/FileCopy'
+import FileCopyOutlinedIcon from '@material-ui/icons/FileCopyOutlined'
 import Snackbar from '@material-ui/core/Snackbar'
 
 const useStyles = makeStyles(() => ({
+  copyBlock: {
+    top: '.3rem',
+    right: '.3rem',
+    width: '1.4rem',
+    height: '1.4rem',
+    borderRadius: '.1rem',
+    fontSize: '.6rem',
+    cursor: 'pointer',
+    zIndex: 1,
+    margin: 0,
+    padding: 0,
+    background: 'transparent',
+    position: 'absolute',
+    border: 0,
+  },
+  copyButton: {
+    backgroundColor: 'transparent',
+    color: 'white',
+    opacity: 0.2,
+    '&:hover': {
+      opacity: 1,
+    },
+  },
   lineWrapper: { display: 'flex' },
   lineNumber: {
     /* background: rgba(255, 255, 255, 0.1); */
@@ -72,20 +95,13 @@ export default function Code (codeBlocks) {
       }
 
       return (
-        <div
-          style={{
-            position: 'absolute',
-            right: '0.25em',
-            border: 0,
-            margin: '0.25px',
-          }}>
-          <IconButton
-            style={{ backgroundColor: 'black', color: 'white' }}
+        <div className={classes.copyBlock}>
+          <IconButton className={classes.copyButton}
             size='small'
             aria-label='copy'
             onClick={handleClick}
           >
-            <FileCopyIcon fontSize='small' />
+            <FileCopyOutlinedIcon fontSize='small' />
           </IconButton>
           <Snackbar
             anchorOrigin={{
@@ -102,15 +118,15 @@ export default function Code (codeBlocks) {
     }
     if (codeBlock && codeBlock.tokenizedLines) {
       return (
-        <div
+        <pre
           className={codeBlock.preClassName}
           style={{ position: 'relative' }}
         >
-          <CopySnackbar />
+          <CopySnackbar/>
           <code className={codeBlock.codeClassName}>
             {codeBlock.tokenizedLines.map(({ html }, i) => (
               <div className={classes.lineWrapper} key={i}>
-                <div className={classes.lineNumber}>{i}</div>
+                <div className={classes.lineNumber}>{i + 1}</div>
                 <div
                   className={classes.lineContents}
                   dangerouslySetInnerHTML={{ __html: html }}
@@ -118,7 +134,7 @@ export default function Code (codeBlocks) {
               </div>
             ))}
           </code>
-        </div>
+        </pre>
       )
     }
     return <pre {...props}/>

--- a/src/components/Code.js
+++ b/src/components/Code.js
@@ -1,0 +1,129 @@
+import { makeStyles } from "@material-ui/core/styles";
+import React from "react";
+import IconButton from "@material-ui/core/IconButton";
+import FileCopyIcon from "@material-ui/icons/FileCopy";
+import Snackbar from "@material-ui/core/Snackbar";
+
+const useStyles = makeStyles((theme) => ({
+  lineWrapper: { display: "flex" },
+  lineNumber: {
+    /* background: rgba(255, 255, 255, 0.1); */
+    width: "1.5rem",
+    opacity: 0.6,
+    "text-align": "right",
+    "user-select": "none",
+  },
+  lineContents: {
+    flex: "1 0 auto",
+    "white-space": "pre",
+  },
+}));
+
+/*
+ * @source https://github.com/gatsbyjs/gatsby/blob/561d33e2e491d3971cb2a404eec9705a5a493602/www/src/utils/copy-to-clipboard.js
+ */
+const copyToClipboard = (str) => {
+  const clipboard = window.navigator.clipboard;
+  /*
+   * fallback to older browsers (including Safari)
+   * if clipboard API not supported
+   */
+  if (!clipboard || typeof clipboard.writeText !== `function`) {
+    const textarea = document.createElement(`textarea`);
+    textarea.value = str;
+    textarea.setAttribute(`readonly`, true);
+    textarea.setAttribute(`contenteditable`, true);
+    textarea.style.position = `absolute`;
+    textarea.style.left = `-9999px`;
+    document.body.appendChild(textarea);
+    textarea.select();
+    const range = document.createRange();
+    const sel = window.getSelection();
+    sel.removeAllRanges();
+    sel.addRange(range);
+    textarea.setSelectionRange(0, textarea.value.length);
+    document.execCommand(`copy`);
+    document.body.removeChild(textarea);
+
+    return Promise.resolve(true);
+  }
+
+  return clipboard.writeText(str);
+};
+
+export default function Code(codeBlocks) {
+  return (props) => {
+    const classes = useStyles();
+    const index = Number(props["data-index"]);
+    const codeBlock = codeBlocks[index];
+    const CopySnackbar = () => {
+      const [open, setOpen] = React.useState(false);
+
+      const handleClick = () => {
+        copyToClipboard(codeBlock.text);
+        setOpen(true);
+      };
+
+      const handleClose = (event, reason) => {
+        if (reason === "clickaway") {
+          return;
+        }
+        setOpen(false);
+      };
+
+      return (
+        <div 
+        style={{
+            position: "absolute",
+            right: "0.25em",
+            border: 0,
+            margin: "0.25px", 
+        }}>
+          <IconButton
+            style={{backgroundColor: 'black', color: 'white'}}
+            size="small"
+            aria-label="copy"
+            onClick={handleClick}
+          >
+            <FileCopyIcon fontSize="small" />
+          </IconButton>
+          <Snackbar
+            anchorOrigin={{
+              vertical: "bottom",
+              horizontal: "center",
+            }}
+            open={open}
+            autoHideDuration={1000}
+            onClose={handleClose}
+            message="源代码已复制"
+          />
+        </div>
+      );
+    };
+    if (codeBlock && codeBlock.tokenizedLines) {
+      console.log(codeBlock.text);
+      return (
+        <div>
+          <div
+            className={codeBlock.preClassName}
+            style={{ position: "relative" }}
+          >
+            <CopySnackbar />
+            <code className={codeBlock.codeClassName}>
+              {codeBlock.tokenizedLines.map(({ html }, i) => (
+                <div className={classes.lineWrapper} key={i}>
+                  <div className={classes.lineNumber}>{i}</div>
+                  <div
+                    className={classes.lineContents}
+                    dangerouslySetInnerHTML={{ __html: html }}
+                  />
+                </div>
+              ))}
+            </code>
+          </div>
+        </div>
+      );
+    }
+    return <pre {...props}></pre>;
+  };
+}

--- a/src/components/doc.js
+++ b/src/components/doc.js
@@ -4,9 +4,11 @@ import React from 'react'
 import Details from './Details'
 import Layout from './Layout'
 import Summary from './Summary'
+import Code from './Code'
 // import Link from './Link'
 
 function mdx ({ data: { mdx }, location }) {
+  // console.log(mdx);
   // const headingTitle = mdx.headings[0] && mdx.headings[0].value
   const title = mdx.slug === '/' ? null : mdx.frontmatter.title
   const description = mdx.frontmatter.description || mdx.excerpt
@@ -16,14 +18,15 @@ function mdx ({ data: { mdx }, location }) {
   const noComment = mdx.frontmatter.noComment || 'false'
   const noEdit = mdx.frontmatter.noEdit || 'false'
   const toc = mdx.toc || null
-  // console.log(mdx)
   const relativePath = mdx.parent.relativePath || ''
   const modifiedTime = mdx.parent.modifiedTime || ''
+  const codeBlocks = mdx.childrenGrvscCodeBlock || null
 
   const myComponents = {
     details: Details,
     summary: Summary,
     // a: Link,
+    pre: Code(codeBlocks),
   }
 
   return (

--- a/src/templates/doc.js
+++ b/src/templates/doc.js
@@ -34,6 +34,17 @@ export const query = graphql`
           modifiedTime(formatString: "YYYY/MM/DD")
         }
       }
+      childrenGrvscCodeBlock {
+        html
+        text
+        preClassName
+        codeClassName
+        tokenizedLines {
+          className
+          html
+          text
+        }
+      }
     }
   }
 `

--- a/src/theme.js
+++ b/src/theme.js
@@ -22,13 +22,13 @@ const globalStyles = withStyles((theme) => ({
       padding: '2px 4px',
       'border-radius': '2px',
       'font-size': '90%',
-      color: theme.palette.inlineCode.color,
-      backgroundColor: theme.palette.inlineCode.background,
+      // color: theme.palette.inlineCode.color,
+      // backgroundColor: theme.palette.inlineCode.background,
     },
     'pre code': {
       'font-size': '100%',
       padding: '0.2em 0',
-      backgroundColor: '#1E1E1E',
+      // backgroundColor: '#1E1E1E',
     },
   },
 }))


### PR DESCRIPTION
### 效果
可见网站：http://damaged-afterthought.surge.sh/
![demo](https://user-images.githubusercontent.com/34876032/82820720-44efa480-9ed5-11ea-93c1-2029fa78287c.gif)

### 依赖
主要依赖插件gatsby-remark-vscode给出的GrvscCodeBlock内部数据（tokenlizedLines）
### 已知问题
目前由于gatsby-remark-vscode对于未指定language的codeblock没有给出需要的数据，所以没有为这些codeblock增加行号以及复制功能。

