### PR TITLE
fix copybutton not always located at top right

### DIFF
--- a/src/components/Code.js
+++ b/src/components/Code.js
@@ -122,7 +122,6 @@ export default function Code (codeBlocks) {
           <CopySnackbar/>
           <pre
             className={codeBlock.preClassName}
-            style={{ position: 'relative' }}
           >
             <code className={codeBlock.codeClassName}>
               {codeBlock.tokenizedLines.map(({ html }, i) => (

--- a/src/components/Code.js
+++ b/src/components/Code.js
@@ -118,23 +118,25 @@ export default function Code (codeBlocks) {
     }
     if (codeBlock && codeBlock.tokenizedLines) {
       return (
-        <pre
-          className={codeBlock.preClassName}
-          style={{ position: 'relative' }}
-        >
+        <div style={{ position: 'relative' }}>
           <CopySnackbar/>
-          <code className={codeBlock.codeClassName}>
-            {codeBlock.tokenizedLines.map(({ html }, i) => (
-              <div className={classes.lineWrapper} key={i}>
-                <div className={classes.lineNumber}>{i + 1}</div>
-                <div
-                  className={classes.lineContents}
-                  dangerouslySetInnerHTML={{ __html: html }}
-                />
-              </div>
-            ))}
-          </code>
-        </pre>
+          <pre
+            className={codeBlock.preClassName}
+            style={{ position: 'relative' }}
+          >
+            <code className={codeBlock.codeClassName}>
+              {codeBlock.tokenizedLines.map(({ html }, i) => (
+                <div className={classes.lineWrapper} key={i}>
+                  <div className={classes.lineNumber}>{i + 1}</div>
+                  <div
+                    className={classes.lineContents}
+                    dangerouslySetInnerHTML={{ __html: html }}
+                  />
+                </div>
+              ))}
+            </code>
+          </pre>
+        </div>
       )
     }
     return <pre {...props}/>


### PR DESCRIPTION
### 效果
![ezgif-1-f3cb00d7b5b1](https://user-images.githubusercontent.com/34876032/82862124-75752400-9f51-11ea-8003-4c9e3d89349b.gif)
### 修改
这个bug应该是copybutton之前放在pre元素里面导致的，参照了一下tf的写法把copybutton拿出来了，让它和pre并列，这样应该就不会受到pre元素的影响瞎跑了