### PR TITLE
perf: load mathjax & images from jsdelivr

### DIFF
--- a/docs/index.md
+++ b/docs/index.md
@@ -9,7 +9,7 @@ description: OI Wiki 是一个编程竞赛知识整合站点，提供有趣又�
 
 # 欢迎来到 **OI Wiki** ！ [![GitHub watchers](https://img.shields.io/github/watchers/OI-wiki/OI-wiki.svg?style=social&label=Watch)](https://github.com/OI-wiki/OI-wiki)  [![GitHub stars](https://img.shields.io/github/stars/OI-wiki/OI-wiki.svg?style=social&label=Stars)](https://github.com/OI-wiki/OI-wiki)
 
- [![Word Art](./images/wordArt.png)](https://github.com/OI-wiki/OI-wiki)
+ [![Word Art](https://cdn.jsdelivr.net/npm/oicdn@0.0.1/wordArt.webp)](https://github.com/OI-wiki/OI-wiki)
 
  **OI** （Olympiad in Informatics，信息学奥林匹克竞赛）在中国起源于 1984 年，是五大高中学科竞赛之一。自 1989 年起，每年还会选拔出国家集训队选手准备 IOI (International Olympiad in Informatics，国际信息学奥林匹克竞赛）。
 
@@ -24,8 +24,8 @@ description: OI Wiki 是一个编程竞赛知识整合站点，提供有趣又�
 Telegram 群组链接为 [@OIwiki](https://t.me/OIwiki) ，QQ 群号码为 [ `588793226` ](https://jq.qq.com/?_wv=1027&k=5EfkM6K) ，欢迎加入。
 
 <div align="center">
-<a href="https://www.hulu.com/" target="_blank"><img height="40px" src="https://i.loli.net/2020/01/24/mtfvuxEFiO8dY1Z.png" /></a>
-<a href="https://www.netlify.com/" target="_blank" style="margin-left: 60px;"><img height="40px" src="https://cn-south-17-rsshub-16857749.oss.dogecdn.com/netlify.png" /></a>
+<a href="https://www.hulu.com/" target="_blank"><img height="40px" src="https://cdn.jsdelivr.net/npm/oicdn@0.0.1/hulu-black.png" /></a>
+<a href="https://www.netlify.com/" target="_blank" style="margin-left: 60px;"><img height="40px" src="https://cdn.jsdelivr.net/npm/oicdn@0.0.1/netlify.png" /></a>
 </div>
 
 ## H2-1

--- a/src/html.js
+++ b/src/html.js
@@ -23,7 +23,7 @@ export default function HTML (props) {
         {props.postBodyComponents}
       </body>
       <script
-        src="https://cdn.staticfile.org/mathjax/3.0.5/es5/tex-mml-chtml.js"
+        src="https://cdn.jsdelivr.net/npm/mathjax@3.0.5/es5/tex-mml-chtml.js"
         id="MathJax-script"
       />
     </html>


### PR DESCRIPTION
The continuation of https://github.com/OI-wiki/OI-wiki/pull/2285.

`cdn.jsdelivr.net` has better cdn pop coverage than `cdn.staticfile.org`.