### PR TITLE
refactor: use native alternative of lodash.throttle

### DIFF
--- a/src/lib/useThrottledOnScroll.js
+++ b/src/lib/useThrottledOnScroll.js
@@ -1,8 +1,19 @@
-import throttle from 'lodash/throttle'
 import { useEffect, useMemo } from 'react'
 
 // eslint-disable-next-line @typescript-eslint/no-empty-function
 const noop = () => {}
+
+// https://github.com/you-dont-need/You-Dont-Need-Lodash-Underscore#_throttle
+function throttle (func, timeFrame) {
+  let lastTime = 0
+  return () => {
+    const now = new Date()
+    if (now - lastTime >= timeFrame) {
+      func()
+      lastTime = now
+    }
+  }
+}
 
 export default function useThrottledOnScroll (callback, delay) {
   const throttledCallback = useMemo(


### PR DESCRIPTION
Ref: https://github.com/you-dont-need/You-Dont-Need-Lodash-Underscore#_throttle

Compatibility:


Chrome  | Edge  | Firefox  | IE  |  Opera |  Safari |
-- | -- | -- | -- | -- | --
5.0 | 12.0 | 3.0 | 9.0 | 10.5 | 4.0
 