### PR TITLE
refactor: embed darkmode script

### DIFF
--- a/src/html.js
+++ b/src/html.js
@@ -1,6 +1,22 @@
 import PropTypes from 'prop-types'
 import React from 'react'
 
+const darkModeSwitch = `window.onthemechange = function (settings) {
+  const fallback = localStorage.settings &&
+    JSON.parse(localStorage.settings).darkMode.type
+  const darkOpt = settings !== undefined ? settings.darkMode.type : fallback
+  let themeClass = 'themeAuto'
+  if (darkOpt === undefined || darkOpt === 'user-preference') {
+    // themeClass = 'themeAuto'
+  } else {
+    themeClass = darkOpt === 'always-on' ? 'themeDark' : 'themeLight'
+  }
+  const docEl = document.querySelector('html')
+  docEl.classList.remove('themeLight', 'themeDark', 'themeAuto')
+  docEl.classList.add(themeClass)
+}
+
+window.onthemechange()`
 export default function HTML (props) {
   return (
     <html lang="zh-cmn-Hans" {...props.htmlAttributes}>
@@ -11,7 +27,9 @@ export default function HTML (props) {
           name="viewport"
           content="width=device-width, initial-scale=1, shrink-to-fit=no"
         />
-        <script src="/script.js"></script>
+        <script dangerouslySetInnerHTML={{
+          __html: darkModeSwitch,
+        }} />
         {props.headComponents}
       </head>
       <body {...props.bodyAttributes}>

--- a/static/script.js
+++ b/static/script.js
@@ -16,3 +16,5 @@ window.onthemechange = function (settings) {
 }
 
 window.onthemechange()
+
+// this file should be MANUALLY inserted into html.js


### PR DESCRIPTION
将暗色模式相关的代码手动嵌入到 head 当中。可以省掉一个请求，或许可以减少这个 js 对渲染的阻塞（？），但是这也造成了一些可维护性的问题。

我不太清楚这样做是不是有意义，如果没有性能没有提升的话，还是维持原样比较好