### PR TITLE
fix error of smallscreenmenu

### DIFF
--- a/gatsby-theme-oi-wiki/src/components/SmallScreenMenu.tsx
+++ b/gatsby-theme-oi-wiki/src/components/SmallScreenMenu.tsx
@@ -1,26 +1,26 @@
-import { makeStyles, useTheme } from '@material-ui/core/styles'
-import React from 'react'
-import Menu from '@material-ui/core/Menu'
-import MenuItem from '@material-ui/core/MenuItem'
-import { ListItemIcon } from '@material-ui/core'
+import {makeStyles} from '@material-ui/core/styles'
+
+import {Menu, MenuItem, IconButton, Hidden, ListItemIcon} from '@material-ui/core'
+
 import SettingsIcon from '@material-ui/icons/Settings'
 import LibraryBooksIcon from '@material-ui/icons/LibraryBooks'
 import LocalOfferIcon from '@material-ui/icons/LocalOffer'
 import GitHubIcon from '@material-ui/icons/GitHub'
 import MoreVertIcon from '@material-ui/icons/MoreVert'
-import IconButton from '@material-ui/core/IconButton'
-import Hidden from '@material-ui/core/Hidden'
+
+import React from 'react'
+
+const useStyles = makeStyles((theme) => ({
+  iconItem: {
+    minWidth: theme.spacing(5),
+  },
+  sideMenu: {
+    transition: 'none !important',
+  },
+}))
 
 const SmallScreenMenu: React.FC<unknown> = function (props) {
   const OIWikiGithub = 'https://github.com/OI-wiki/OI-wiki'
-  const useStyles = makeStyles((theme) => ({
-    iconItem: {
-      minWidth: theme.spacing(5),
-    },
-    sideMenu: {
-      transition: 'none !important',
-    },
-  }))
 
   const classes = useStyles({
 
@@ -47,28 +47,28 @@ const SmallScreenMenu: React.FC<unknown> = function (props) {
         open={Boolean(anchorEl)}
         onClose={handleClose}
         // TransitionComponent={({children}) => children}
-        TransitionProps={{ timeout: 0 }}
-        classes = {{ root: classes.sideMenu }}
+        TransitionProps={{timeout: 0}}
+        classes={{list: classes.sideMenu}}
       >
         <MenuItem component="a" href="/settings">
-          <ListItemIcon classes={{ root: classes.iconItem }}>
+          <ListItemIcon classes={{root: classes.iconItem}}>
             <SettingsIcon fontSize="small" />
           </ListItemIcon>
     设置
         </MenuItem>
         <MenuItem component="a" href="/tags">
-          <ListItemIcon classes={{ root: classes.iconItem }}>
+          <ListItemIcon classes={{root: classes.iconItem}}>
             <LocalOfferIcon fontSize="small" />
           </ListItemIcon>
     标签
         </MenuItem>
         <MenuItem component="a" href="/pages">
-          <ListItemIcon classes={{ root: classes.iconItem }}>
+          <ListItemIcon classes={{root: classes.iconItem}}>
             <LibraryBooksIcon fontSize="small" />
           </ListItemIcon>
     目录</MenuItem>
         <MenuItem component="a" href={OIWikiGithub}>
-          <ListItemIcon classes={{ root: classes.iconItem }}>
+          <ListItemIcon classes={{root: classes.iconItem}}>
             <GitHubIcon fontSize="small" />
           </ListItemIcon>
     GitHub</MenuItem>


### PR DESCRIPTION
结论是：把 classes 的 root 改成 list 就对了（vscode的报错也会消失

[ref](https://material-ui.com/zh/api/menu/#css)

似乎是因为 MUI 的 menu 没有root，只有list和paper可选