### PR TITLE
修复目录页的 bug

### DIFF
--- a/gatsby-theme-oi-wiki/src/pages/pages.js
+++ b/gatsby-theme-oi-wiki/src/pages/pages.js
@@ -148,8 +148,10 @@ function BlogIndex (props) {
             )}
           />
         </Grid>
-        <Grid container xs={12} spacing={2} justify="center">
-          <GridItems filteredItems={filteredItems} linkComponent={MyLink} />
+        <Grid item xs={12}>
+          <Grid container spacing={2} justify="center">
+            <GridItems filteredItems={filteredItems} linkComponent={MyLink} />
+          </Grid>
         </Grid>
       </Grid>
     </Layout>


### PR DESCRIPTION
Grid 的 container 似乎不能和xs一起用，会报一个很长的错
得外面套一个Grid item