### PR TITLE
fix: avoid cache page data

### DIFF
--- a/gatsby-theme-oi-wiki/gatsby-config.js
+++ b/gatsby-theme-oi-wiki/gatsby-config.js
@@ -108,7 +108,7 @@ module.exports = {
         precachePages: [],
         workboxConfig: {
           importWorkboxFrom: 'local',
-          globPatterns: ['page-data/**', '*.js'],
+          globPatterns: ['*.js'],
           runtimeCaching: [
             {
               urlPattern: /(\.js$|\.css$)/, // js and css


### PR DESCRIPTION
in the full build, cache size can be larger than 80MB