### PR TITLE
ci(dependabot.yml): restrict uncontrollable dependency updates

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -5,3 +5,9 @@ updates:
   schedule:
     interval: monthly
   open-pull-requests-limit: 10
+  ignore:
+    - dependency-name: typescript
+      versions:
+        - ">=4.4.0"
+    - dependency-name: "@typescript-eslint/parser"
+    - dependency-name: "@typescript-eslint/eslint-plugin"


### PR DESCRIPTION
* block update typescript to unsupported version
* ignore typescript-eslint's parser & eslint-plugin