### PR TITLE
chore: set eslint rule 'semi' to 'always'

### DIFF
--- a/gatsby-theme-oi-wiki/.eslintrc.js
+++ b/gatsby-theme-oi-wiki/.eslintrc.js
@@ -34,7 +34,7 @@ module.exports = {
   rules: {
     'object-curly-spacing': ['error', 'always'],
     'quotes': ['error', 'single', { 'allowTemplateLiterals': true }],
-    'semi': ['error', 'never', { 'beforeStatementContinuationChars': 'always' }],
+    'semi': ['error', 'always'],
     'react/prop-types': 'off',
     'comma-dangle': ['error', 'always-multiline'],
     'no-unused-vars': 'warn',

--- a/gatsby-theme-oi-wiki/src/components/AuthorsArray.tsx
+++ b/gatsby-theme-oi-wiki/src/components/AuthorsArray.tsx
@@ -1,20 +1,20 @@
-import Chip from '@material-ui/core/Chip'
-import { makeStyles } from '@material-ui/core/styles'
-import React from 'react'
+import Chip from '@material-ui/core/Chip';
+import { makeStyles } from '@material-ui/core/styles';
+import React from 'react';
 
 const useStyles = makeStyles((theme) => ({
   chip: {
     margin: theme.spacing(0.5),
   },
-}))
+}));
 
 export interface AuthorsArrayProps {
   authors: string;
 }
 
 const AuthorsArray: React.FC<AuthorsArrayProps> = ({ authors }) => {
-  const arr = authors?.split(',').map((x) => x.trim())
-  const classes = useStyles()
+  const arr = authors?.split(',').map((x) => x.trim());
+  const classes = useStyles();
   return (
     <div>
       {arr?.map((author) => (
@@ -31,7 +31,7 @@ const AuthorsArray: React.FC<AuthorsArrayProps> = ({ authors }) => {
         />
       ))}
     </div>
-  )
-}
+  );
+};
 
-export default AuthorsArray
+export default AuthorsArray;

--- a/gatsby-theme-oi-wiki/src/components/BackTop.tsx
+++ b/gatsby-theme-oi-wiki/src/components/BackTop.tsx
@@ -1,11 +1,11 @@
-import Fab from '@material-ui/core/Fab'
-import { makeStyles } from '@material-ui/core/styles'
-import Zoom from '@material-ui/core/Zoom'
-import ArrowUpward from '@material-ui/icons/ArrowUpward'
-import React, { useState } from 'react'
-import useThrottledOnScroll from '../lib/useThrottledOnScroll'
-import smoothScrollTo from '../lib/smoothScroll'
-import { OnClickHandler } from '../types/common'
+import Fab from '@material-ui/core/Fab';
+import { makeStyles } from '@material-ui/core/styles';
+import Zoom from '@material-ui/core/Zoom';
+import ArrowUpward from '@material-ui/icons/ArrowUpward';
+import React, { useState } from 'react';
+import useThrottledOnScroll from '../lib/useThrottledOnScroll';
+import smoothScrollTo from '../lib/smoothScroll';
+import { OnClickHandler } from '../types/common';
 
 const useStyles = makeStyles((theme) => ({
   fab: {
@@ -23,22 +23,22 @@ const useStyles = makeStyles((theme) => ({
     right: theme.spacing(8),
     zIndex: 2,
   },
-}))
+}));
 
 const BackTop: React.FC = () => {
-  const classes = useStyles()
+  const classes = useStyles();
   const handleClick: OnClickHandler<HTMLButtonElement> = () => {
-    smoothScrollTo(0)
-  }
-  const [yPos, setYPos] = useState(0)
-  useThrottledOnScroll(() => setYPos(window.scrollY), 166)
+    smoothScrollTo(0);
+  };
+  const [yPos, setYPos] = useState(0);
+  useThrottledOnScroll(() => setYPos(window.scrollY), 166);
   return (
     <Zoom in={yPos > 400}>
       <Fab disableRipple className={classes.fab} onClick={handleClick}>
         <ArrowUpward/>
       </Fab>
     </Zoom>
-  )
-}
+  );
+};
 
-export default BackTop
+export default BackTop;

--- a/gatsby-theme-oi-wiki/src/components/Code.tsx
+++ b/gatsby-theme-oi-wiki/src/components/Code.tsx
@@ -1,12 +1,12 @@
-import { Box, IconButton, makeStyles, Tooltip } from '@material-ui/core'
-import AssignmentOutlined from '@material-ui/icons/AssignmentOutlined'
-import CodeOutlined from '@material-ui/icons/CodeOutlined'
-import clsx from 'clsx'
-import { navigate } from 'gatsby'
-import has from 'lodash/has'
-import React, { useCallback, useRef, useState } from 'react'
-import type { LangType } from '../lib/play/codeLang'
-import type { PlaygroundLocationState } from '../pages/play'
+import { Box, IconButton, makeStyles, Tooltip } from '@material-ui/core';
+import AssignmentOutlined from '@material-ui/icons/AssignmentOutlined';
+import CodeOutlined from '@material-ui/icons/CodeOutlined';
+import clsx from 'clsx';
+import { navigate } from 'gatsby';
+import has from 'lodash/has';
+import React, { useCallback, useRef, useState } from 'react';
+import type { LangType } from '../lib/play/codeLang';
+import type { PlaygroundLocationState } from '../pages/play';
 
 const useStyles = makeStyles((theme) => ({
   container: {
@@ -23,30 +23,30 @@ const useStyles = makeStyles((theme) => ({
   runBtn: {
     right: theme.spacing(4) + 8,
   },
-}))
+}));
 
 // map to lang defined in codeLang.ts
 const mdxLangMap: Readonly<Record<string, LangType>> = Object.freeze({
   cpp: 'C++',
   python: 'Python3',
-})
+});
 
 const Code: React.FC<{
   children: React.ReactNode
   className: string
   'data-language': string
 }> = ({ children, 'data-language': dataLanguage, className, ...rest }) => {
-  const classes = useStyles()
+  const classes = useStyles();
 
-  const boxRef = useRef<HTMLElement>(null)
+  const boxRef = useRef<HTMLElement>(null);
   const getCode = useCallback(
     () => boxRef.current?.querySelector('pre')?.innerText,
     [],
-  )
+  );
 
   const [copyToolTipText, setCopyToolTipText] = useState<'复制' | '已复制'>(
     '复制',
-  )
+  );
 
   return (
     <Box
@@ -61,8 +61,8 @@ const Code: React.FC<{
         onClose={() => {
           // workaround for delay of css transition
           setTimeout(() => {
-            setCopyToolTipText('复制')
-          }, 250)
+            setCopyToolTipText('复制');
+          }, 250);
         }}
         arrow
       >
@@ -70,11 +70,11 @@ const Code: React.FC<{
           className={clsx(classes.btn, classes.clipboardBtn)}
           aria-label="copy"
           onClick={() => {
-            const code = getCode()
+            const code = getCode();
             if (code !== undefined) {
               navigator.clipboard.writeText(code).then(() => {
-                setCopyToolTipText('已复制')
-              })
+                setCopyToolTipText('已复制');
+              });
             }
           }}
         >
@@ -91,7 +91,7 @@ const Code: React.FC<{
                 code: getCode(),
                 lang: mdxLangMap[dataLanguage],
               } as PlaygroundLocationState,
-            })
+            });
           }}
           aria-label="run"
         >
@@ -100,7 +100,7 @@ const Code: React.FC<{
       </Tooltip>
       {children}
     </Box>
-  )
-}
+  );
+};
 
-export default Code
+export default Code;

--- a/gatsby-theme-oi-wiki/src/components/CodeEditor/Editor.tsx
+++ b/gatsby-theme-oi-wiki/src/components/CodeEditor/Editor.tsx
@@ -1,23 +1,23 @@
-import React from 'react'
-import Ace from 'react-ace'
-import useDarkMode from '../../lib/useDarkMode'
-import { langModeMap } from '../../lib/play/codeLang'
+import React from 'react';
+import Ace from 'react-ace';
+import useDarkMode from '../../lib/useDarkMode';
+import { langModeMap } from '../../lib/play/codeLang';
 
 // add language to support here
-import 'ace-builds/src-noconflict/mode-c_cpp'
-import 'ace-builds/src-noconflict/mode-python'
+import 'ace-builds/src-noconflict/mode-c_cpp';
+import 'ace-builds/src-noconflict/mode-python';
 
 // light/dark theme
-import 'ace-builds/src-noconflict/theme-chrome'
-import 'ace-builds/src-noconflict/theme-tomorrow_night'
+import 'ace-builds/src-noconflict/theme-chrome';
+import 'ace-builds/src-noconflict/theme-tomorrow_night';
 
-import { CodeEditorProps } from '.'
+import { CodeEditorProps } from '.';
 
 const Editor: React.FC<Omit<CodeEditorProps, 'title'>> = ({
   lang,
   ...aceProps
 }) => {
-  const isDarkMode = useDarkMode()
+  const isDarkMode = useDarkMode();
 
   return (
     <Ace
@@ -28,7 +28,7 @@ const Editor: React.FC<Omit<CodeEditorProps, 'title'>> = ({
       mode={lang ? langModeMap[lang] : 'text'}
       {...aceProps}
     />
-  )
-}
+  );
+};
 
-export default Editor
+export default Editor;

--- a/gatsby-theme-oi-wiki/src/components/CodeEditor/index.tsx
+++ b/gatsby-theme-oi-wiki/src/components/CodeEditor/index.tsx
@@ -1,8 +1,8 @@
-import { makeStyles, Paper, Typography } from '@material-ui/core'
-import React from 'react'
+import { makeStyles, Paper, Typography } from '@material-ui/core';
+import React from 'react';
 
-import type { IAceEditorProps } from 'react-ace'
-import type { LangType } from '../../lib/play/codeLang'
+import type { IAceEditorProps } from 'react-ace';
+import type { LangType } from '../../lib/play/codeLang';
 
 export interface CodeEditorProps extends Omit<IAceEditorProps, 'mode'> {
   title: string
@@ -16,17 +16,17 @@ const useStyles = makeStyles({
   editor: {
     height: '100%',
   },
-})
+});
 
 // fix ssr issue related to react-ace
-const Editor = React.lazy(() => import('./Editor'))
+const Editor = React.lazy(() => import('./Editor'));
 
 const CodeEditor: React.FC<CodeEditorProps> = ({
   title,
   lang,
   ...aceProps
 }) => {
-  const classes = useStyles()
+  const classes = useStyles();
 
   return (
     <>
@@ -39,7 +39,7 @@ const CodeEditor: React.FC<CodeEditorProps> = ({
         )}
       </Paper>
     </>
-  )
-}
+  );
+};
 
-export default CodeEditor
+export default CodeEditor;

--- a/gatsby-theme-oi-wiki/src/components/CodeLangMenu.tsx
+++ b/gatsby-theme-oi-wiki/src/components/CodeLangMenu.tsx
@@ -1,9 +1,9 @@
-import type { ButtonProps } from '@material-ui/core'
-import { Button, Menu, MenuItem } from '@material-ui/core'
-import ArrowDropDownOutlined from '@material-ui/icons/ArrowDropDownOutlined'
-import React, { useCallback, useState } from 'react'
-import type { LangType } from '../lib/play/codeLang'
-import { langList } from '../lib/play/codeLang'
+import type { ButtonProps } from '@material-ui/core';
+import { Button, Menu, MenuItem } from '@material-ui/core';
+import ArrowDropDownOutlined from '@material-ui/icons/ArrowDropDownOutlined';
+import React, { useCallback, useState } from 'react';
+import type { LangType } from '../lib/play/codeLang';
+import { langList } from '../lib/play/codeLang';
 
 interface CodeLangMenuProps extends ButtonProps {
   lang: LangType
@@ -15,19 +15,19 @@ const CodeLangMenu: React.FC<CodeLangMenuProps> = ({
   setLang,
   ...buttonProps
 }) => {
-  const [anchorEl, setAnchorEl] = useState<HTMLElement | null>(null)
+  const [anchorEl, setAnchorEl] = useState<HTMLElement | null>(null);
 
   const handleButtonClick = useCallback((e: React.MouseEvent<HTMLElement>) => {
-    setAnchorEl(e.currentTarget)
-  }, [])
+    setAnchorEl(e.currentTarget);
+  }, []);
 
   const handleItemClick = useCallback(
     (_: React.MouseEvent<HTMLLIElement>, index: number) => {
-      setLang(langList[index] as LangType)
-      setAnchorEl(null)
+      setLang(langList[index] as LangType);
+      setAnchorEl(null);
     },
     [setLang],
-  )
+  );
 
   return (
     <>
@@ -42,7 +42,7 @@ const CodeLangMenu: React.FC<CodeLangMenuProps> = ({
         open={!!anchorEl}
         anchorEl={anchorEl}
         onClose={() => {
-          setAnchorEl(null)
+          setAnchorEl(null);
         }}
       >
         {langList.map((l, index) => (
@@ -56,7 +56,7 @@ const CodeLangMenu: React.FC<CodeLangMenuProps> = ({
         ))}
       </Menu>
     </>
-  )
-}
+  );
+};
 
-export default CodeLangMenu
+export default CodeLangMenu;

--- a/gatsby-theme-oi-wiki/src/components/Codetab.tsx
+++ b/gatsby-theme-oi-wiki/src/components/Codetab.tsx
@@ -1,20 +1,20 @@
-import Tab from '@material-ui/core/Tab'
-import Tabs from '@material-ui/core/Tabs'
-import React from 'react'
+import Tab from '@material-ui/core/Tab';
+import Tabs from '@material-ui/core/Tabs';
+import React from 'react';
 
 interface CodetabProp {
     'tab-labels': string;
 }
 
 const Codetab: React.FC<CodetabProp> = ({ children, ...rest }) => {
-    const [value, setValue] = React.useState(0)
-    const cont = Array.isArray(children) ? children : [children]
+    const [value, setValue] = React.useState(0);
+    const cont = Array.isArray(children) ? children : [children];
 
     const handleChange = (_: unknown, newValue: number): void => {
-        setValue(newValue)
-    }
+        setValue(newValue);
+    };
 
-    const labels = rest['tab-labels']?.split(',')
+    const labels = rest['tab-labels']?.split(',');
     return (
         <div>
             <Tabs
@@ -24,15 +24,15 @@ const Codetab: React.FC<CodetabProp> = ({ children, ...rest }) => {
                 textColor="primary"
             >
                 {cont?.map((_, i) => {
-                    return <Tab label={labels?.[i] ?? 'Code'} key={i} />
+                    return <Tab label={labels?.[i] ?? 'Code'} key={i} />;
                 })}
             </Tabs>
 
             {cont?.map((e, i) => {
-                return <div role="tabpanel" hidden={value !== i} key={i}>{e}</div>
+                return <div role="tabpanel" hidden={value !== i} key={i}>{e}</div>;
             })}
         </div>
-    )
-}
+    );
+};
 
-export default Codetab
+export default Codetab;

--- a/gatsby-theme-oi-wiki/src/components/Comment/Card/ReactionButton.tsx
+++ b/gatsby-theme-oi-wiki/src/components/Comment/Card/ReactionButton.tsx
@@ -2,20 +2,20 @@ import {
   Avatar,
   Button,
   CircularProgress,
-} from '@material-ui/core'
+} from '@material-ui/core';
 
-import React, { useState } from 'react'
-import AvatarGroup from '@material-ui/lab/AvatarGroup'
-import clsx from 'clsx'
-import { User } from '@mgtd/vssue-api-github-v4/lib/types'
-import { useStyles } from './styles'
+import React, { useState } from 'react';
+import AvatarGroup from '@material-ui/lab/AvatarGroup';
+import clsx from 'clsx';
+import { User } from '@mgtd/vssue-api-github-v4/lib/types';
+import { useStyles } from './styles';
 
-import { SvgIconComponent } from '@material-ui/icons'
+import { SvgIconComponent } from '@material-ui/icons';
 
 const reactionButtonDefaultProps = {
   initialCount: 0,
   isClicked: false,
-}
+};
 
 type ReactionButtonProps = {
   icon: SvgIconComponent
@@ -28,31 +28,31 @@ type ReactionButtonProps = {
 } & Partial<typeof reactionButtonDefaultProps>
 
 const ReactionButton: React.FC<ReactionButtonProps> = (props) => {
-  const classes = useStyles()
-  const propsMerged = { ...reactionButtonDefaultProps, ...props }
-  const [isClicked, setIsClicked] = useState(propsMerged.isClicked)
-  const [count, setCount] = useState(propsMerged.initialCount)
-  const [users, setUsers] = useState(propsMerged.users)
-  const [loading, setLoading] = useState(false)
+  const classes = useStyles();
+  const propsMerged = { ...reactionButtonDefaultProps, ...props };
+  const [isClicked, setIsClicked] = useState(propsMerged.isClicked);
+  const [count, setCount] = useState(propsMerged.initialCount);
+  const [users, setUsers] = useState(propsMerged.users);
+  const [loading, setLoading] = useState(false);
   const clickFunc = async (): Promise<void> => {
     if (isClicked) {
-      setCount(count - 1)
-      setLoading(true)
-      await propsMerged.removeReaction()
-      setLoading(false)
-      const tmpUsers = users.filter(({ username }) => username !== propsMerged.currentUser.username)
-      setUsers(tmpUsers)
+      setCount(count - 1);
+      setLoading(true);
+      await propsMerged.removeReaction();
+      setLoading(false);
+      const tmpUsers = users.filter(({ username }) => username !== propsMerged.currentUser.username);
+      setUsers(tmpUsers);
     } else {
-      setCount(count + 1)
-      setLoading(true)
-      await propsMerged.addReaction()
-      setLoading(false)
-      const tmpUsers: User[] = [...users, propsMerged.currentUser]
-      setUsers(tmpUsers)
+      setCount(count + 1);
+      setLoading(true);
+      await propsMerged.addReaction();
+      setLoading(false);
+      const tmpUsers: User[] = [...users, propsMerged.currentUser];
+      setUsers(tmpUsers);
     }
-    setIsClicked(!isClicked)
-  }
-  const SvgTag = props.icon
+    setIsClicked(!isClicked);
+  };
+  const SvgTag = props.icon;
   return (
     <Button
       color="default"
@@ -70,7 +70,7 @@ const ReactionButton: React.FC<ReactionButtonProps> = (props) => {
         ))}
       </AvatarGroup>}
     </Button>
-  )
-}
+  );
+};
 
-export default ReactionButton
+export default ReactionButton;

--- a/gatsby-theme-oi-wiki/src/components/Comment/Card/index.tsx
+++ b/gatsby-theme-oi-wiki/src/components/Comment/Card/index.tsx
@@ -6,7 +6,7 @@ import {
   CardHeader,
   CircularProgress,
   IconButton,
-} from '@material-ui/core'
+} from '@material-ui/core';
 
 import {
   Favorite as FavoriteIcon,
@@ -14,15 +14,15 @@ import {
   ThumbDown as ThumbDownIcon,
   Reply as ReplyIcon,
   Delete as DeleteIcon,
-} from '@material-ui/icons'
+} from '@material-ui/icons';
 
-import React, { useState } from 'react'
-import { User } from '@mgtd/vssue-api-github-v4/lib/types'
-import Time from '../../Time'
-import { Reactions } from '../types'
-import { useInputContentContext } from '../inputContext'
-import { useStyles } from './styles'
-import ReactionButton from './ReactionButton'
+import React, { useState } from 'react';
+import { User } from '@mgtd/vssue-api-github-v4/lib/types';
+import Time from '../../Time';
+import { Reactions } from '../types';
+import { useInputContentContext } from '../inputContext';
+import { useStyles } from './styles';
+import ReactionButton from './ReactionButton';
 
 interface Props {
   disabled: boolean,
@@ -40,13 +40,13 @@ interface Props {
 }
 
 const CommentCard: React.FC<Props> = (props) => {
-  const { name, time, disabled, currentUser, reactions, commentID } = props
-  const classes = useStyles()
-  const like = reactions.find(item => item.type === 'like')
-  const unlike = reactions.find(item => item.type === 'unlike')
-  const heart = reactions.find(item => item.type === 'heart')
-  const [deleteLoading, setDeleteLoading] = useState(false)
-  const { setInputContent } = useInputContentContext()
+  const { name, time, disabled, currentUser, reactions, commentID } = props;
+  const classes = useStyles();
+  const like = reactions.find(item => item.type === 'like');
+  const unlike = reactions.find(item => item.type === 'unlike');
+  const heart = reactions.find(item => item.type === 'heart');
+  const [deleteLoading, setDeleteLoading] = useState(false);
+  const { setInputContent } = useInputContentContext();
   return (
     <Card variant="outlined" className={classes.commentMargin}>
       <CardHeader
@@ -59,7 +59,7 @@ const CommentCard: React.FC<Props> = (props) => {
               aria-label="delete"
               className={classes.floatRight}
               onClick={
-                () => { props.deleteComment(commentID, setDeleteLoading) }
+                () => { props.deleteComment(commentID, setDeleteLoading); }
               }>
               {deleteLoading
                 ? <CircularProgress size={20} />
@@ -70,7 +70,7 @@ const CommentCard: React.FC<Props> = (props) => {
             aria-label="reply"
             className={classes.floatRight}
             onClick={() => {
-              setInputContent(`> ${props.contentRaw}`)
+              setInputContent(`> ${props.contentRaw}`);
             }}>
             <ReplyIcon fontSize="small" />
           </IconButton>
@@ -88,8 +88,8 @@ const CommentCard: React.FC<Props> = (props) => {
           currentUser={currentUser}
           initialCount={like.count}
           isClicked={like.viewerHasReacted}
-          addReaction={async () => { await props.addReaction(commentID, 'like') }}
-          removeReaction={async () => { await props.removeReaction(commentID, 'like') }}
+          addReaction={async () => { await props.addReaction(commentID, 'like'); }}
+          removeReaction={async () => { await props.removeReaction(commentID, 'like'); }}
           users={like.users}
         />
         <ReactionButton
@@ -99,8 +99,8 @@ const CommentCard: React.FC<Props> = (props) => {
           currentUser={currentUser}
           initialCount={unlike.count}
           isClicked={unlike.viewerHasReacted}
-          addReaction={async () => { await props.addReaction(commentID, 'unlike') }}
-          removeReaction={async () => { await props.removeReaction(commentID, 'unlike') }}
+          addReaction={async () => { await props.addReaction(commentID, 'unlike'); }}
+          removeReaction={async () => { await props.removeReaction(commentID, 'unlike'); }}
           users={unlike.users}
         />
         <ReactionButton
@@ -110,12 +110,12 @@ const CommentCard: React.FC<Props> = (props) => {
           currentUser={currentUser}
           initialCount={heart.count}
           isClicked={heart.viewerHasReacted}
-          addReaction={async () => { await props.addReaction(commentID, 'heart') }}
-          removeReaction={async () => { await props.removeReaction(commentID, 'heart') }}
+          addReaction={async () => { await props.addReaction(commentID, 'heart'); }}
+          removeReaction={async () => { await props.removeReaction(commentID, 'heart'); }}
           users={heart.users}
         />
       </CardActions>
-    </Card>)
-}
+    </Card>);
+};
 
-export default CommentCard
+export default CommentCard;

--- a/gatsby-theme-oi-wiki/src/components/Comment/Card/styles.ts
+++ b/gatsby-theme-oi-wiki/src/components/Comment/Card/styles.ts
@@ -1,5 +1,5 @@
-import { makeStyles } from '@material-ui/core'
-import Red from '@material-ui/core/colors/red'
+import { makeStyles } from '@material-ui/core';
+import Red from '@material-ui/core/colors/red';
 
 export const useStyles = makeStyles(theme => ({
   contentRoot: {
@@ -45,4 +45,4 @@ export const useStyles = makeStyles(theme => ({
   floatRight: {
     float: 'right',
   },
-}))
+}));

--- a/gatsby-theme-oi-wiki/src/components/Comment/Comment.tsx
+++ b/gatsby-theme-oi-wiki/src/components/Comment/Comment.tsx
@@ -1,15 +1,15 @@
-import { Button, CircularProgress, Divider, makeStyles, Tooltip, Typography } from '@material-ui/core'
-import React, { useEffect, useState } from 'react'
-import GithubV3 from '@mgtd/vssue-api-github-v3'
-import GithubV4 from '@mgtd/vssue-api-github-v4'
-import createPersistedState from 'use-persisted-state'
-import CommentCard from './Card'
-import CommentInput from './CommentInput'
-import { Comments, Issue, User } from './types'
-import { InputContentProvider } from './inputContext'
-import { getComments } from './api'
+import { Button, CircularProgress, Divider, makeStyles, Tooltip, Typography } from '@material-ui/core';
+import React, { useEffect, useState } from 'react';
+import GithubV3 from '@mgtd/vssue-api-github-v3';
+import GithubV4 from '@mgtd/vssue-api-github-v4';
+import createPersistedState from 'use-persisted-state';
+import CommentCard from './Card';
+import CommentInput from './CommentInput';
+import { Comments, Issue, User } from './types';
+import { InputContentProvider } from './inputContext';
+import { getComments } from './api';
 
-const useToken = createPersistedState('github-access-token')
+const useToken = createPersistedState('github-access-token');
 
 interface Props {
   clientID: string,
@@ -24,24 +24,24 @@ const useStyles = makeStyles((theme) => ({
   link: {
     color: theme.palette.text.primary,
   },
-}))
+}));
 
 const CommentComponent: React.FC<Props> = (props) => {
-  const classes = useStyles()
-  const defaultUser = { username: '未登录用户', avatar: undefined, homepage: undefined }
-  const [token, setToken] = useToken(null)
+  const classes = useStyles();
+  const defaultUser = { username: '未登录用户', avatar: undefined, homepage: undefined };
+  const [token, setToken] = useToken(null);
   const revokeToken = (): void => {
-    setToken(null)
-    setUser(defaultUser)
-  }
-  const [user, setUser] = useState<User>(defaultUser)
-  const [comments, setComments] = useState<Comments>({ count: 0, page: 0, perPage: 0, data: [] })
-  const [noIssue, setNoIssue] = useState(false)
-  const filteredComments = comments.data.filter(({ isMinimized }) => !isMinimized)
-  const [issue, setIssue] = useState<Issue>()
-  const [createIssueLoading, setCreateIssueLoading] = useState(false)
-  const authorized = user.username !== '未登录用户' && token && !noIssue
-  const isAdmin = props.admin.indexOf(user.username) >= 0
+    setToken(null);
+    setUser(defaultUser);
+  };
+  const [user, setUser] = useState<User>(defaultUser);
+  const [comments, setComments] = useState<Comments>({ count: 0, page: 0, perPage: 0, data: [] });
+  const [noIssue, setNoIssue] = useState(false);
+  const filteredComments = comments.data.filter(({ isMinimized }) => !isMinimized);
+  const [issue, setIssue] = useState<Issue>();
+  const [createIssueLoading, setCreateIssueLoading] = useState(false);
+  const authorized = user.username !== '未登录用户' && token && !noIssue;
+  const isAdmin = props.admin.indexOf(user.username) >= 0;
   const ghAPIV3 = new GithubV3({
     baseURL: 'https://github.com',
     owner: props.owner,
@@ -51,7 +51,7 @@ const CommentComponent: React.FC<Props> = (props) => {
     clientSecret: props.clientSecret,
     state: '123',
     proxy: url => `https://cors-anywhere.mgt.workers.dev/?${url}`,
-  })
+  });
   const ghAPIV4 = new GithubV4({
     baseURL: 'https://github.com',
     owner: props.owner,
@@ -61,57 +61,57 @@ const CommentComponent: React.FC<Props> = (props) => {
     clientSecret: props.clientSecret,
     state: '123',
     proxy: url => `https://cors-anywhere.mgt.workers.dev/?${url}`,
-  })
+  });
   useEffect(() => {
     const asyncFunc = async (): Promise<void> => {
-      let tk = token
+      let tk = token;
       if (!tk) {
-        tk = await ghAPIV3.handleAuth()
+        tk = await ghAPIV3.handleAuth();
         if (tk !== null) {
-          setToken(tk)
+          setToken(tk);
         }
       }
-      const tmp = await getComments(ghAPIV3, ghAPIV4, props.id, revokeToken, tk)
+      const tmp = await getComments(ghAPIV3, ghAPIV4, props.id, revokeToken, tk);
       if (tmp === 'noIssue') {
-        setNoIssue(true)
+        setNoIssue(true);
       } else if (tmp !== 'invalidToken') {
-        const [i, c] = tmp
-        setComments(c)
-        setIssue(i)
+        const [i, c] = tmp;
+        setComments(c);
+        setIssue(i);
       }
-      const u: User = await ghAPIV3.getUser({ accessToken: tk })
-      setUser(u)
-    }
+      const u: User = await ghAPIV3.getUser({ accessToken: tk });
+      setUser(u);
+    };
 
     asyncFunc().catch(reject => {
-      console.log(reject)
-    })
+      console.log(reject);
+    });
 
     // eslint-disable-next-line react-hooks/exhaustive-deps
-  }, [props.clientID, props.clientSecret, props.id])
+  }, [props.clientID, props.clientSecret, props.id]);
   const updateComments = async (): Promise<void> => {
-    const tmp = await getComments(ghAPIV3, ghAPIV4, props.id, revokeToken, token)
+    const tmp = await getComments(ghAPIV3, ghAPIV4, props.id, revokeToken, token);
     if (tmp !== 'invalidToken' && tmp !== 'noIssue') {
-      const [, c] = tmp
-      setComments(c)
+      const [, c] = tmp;
+      setComments(c);
     }
-  }
+  };
   const NoIssueComponent = (): React.ReactElement => {
     return isAdmin
       ? <Typography variant="body1" style={{ padding: '24px', textAlign: 'center' }}>
         <Button variant="outlined" color="primary" disabled={createIssueLoading}
                 onClick={async () => {
-                  setCreateIssueLoading(true)
-                  await ghAPIV4.postIssue({ accessToken: token, title: props.id, content: location.href })
+                  setCreateIssueLoading(true);
+                  await ghAPIV4.postIssue({ accessToken: token, title: props.id, content: location.href });
                   // sleep 1s, 直接查询会返回无结果，迷惑
-                  await new Promise(resolve => setTimeout(resolve, 1000))
-                  const tmp = await getComments(ghAPIV3, ghAPIV4, props.id, revokeToken, token)
-                  setCreateIssueLoading(false)
+                  await new Promise(resolve => setTimeout(resolve, 1000));
+                  const tmp = await getComments(ghAPIV3, ghAPIV4, props.id, revokeToken, token);
+                  setCreateIssueLoading(false);
                   if (tmp !== 'invalidToken' && tmp !== 'noIssue') {
-                    const [i, c] = tmp
-                    setNoIssue(false)
-                    setComments(c)
-                    setIssue(i)
+                    const [i, c] = tmp;
+                    setNoIssue(false);
+                    setComments(c);
+                    setIssue(i);
                   }
                 }}>
           为本页面创建 Issue
@@ -120,8 +120,8 @@ const CommentComponent: React.FC<Props> = (props) => {
       </Typography>
       : <Typography variant="body1" style={{ padding: '24px', textAlign: 'center' }}>
         没有找到与本页面相关联的 issue
-      </Typography>
-  }
+      </Typography>;
+  };
   return (
     <InputContentProvider>
       <Typography variant="h6">
@@ -133,10 +133,10 @@ const CommentComponent: React.FC<Props> = (props) => {
             style={{ float: 'right', cursor: 'pointer' }}
             onClick={() => {
               if (!token) {
-                ghAPIV3.redirectAuth()
+                ghAPIV3.redirectAuth();
               } else {
-                setToken(null)
-                setUser(defaultUser)
+                setToken(null);
+                setUser(defaultUser);
               }
             }}
           >
@@ -151,18 +151,18 @@ const CommentComponent: React.FC<Props> = (props) => {
         authorized={authorized}
         showLogin={token === null}
         handleLogin={() => {
-          ghAPIV3.redirectAuth()
+          ghAPIV3.redirectAuth();
         }}
         sendComment={async (v, setLoading) => {
-          setLoading(true)
+          setLoading(true);
           try {
-            await ghAPIV3.postComment({ accessToken: token, issueId: issue.id, content: v })
+            await ghAPIV3.postComment({ accessToken: token, issueId: issue.id, content: v });
           } catch (e) {
-            setLoading(false)
-            return
+            setLoading(false);
+            return;
           }
-          updateComments()
-          setLoading(false)
+          updateComments();
+          setLoading(false);
         }}
       />
       {noIssue
@@ -180,22 +180,22 @@ const CommentComponent: React.FC<Props> = (props) => {
             currentUser={user}
             commentID={id}
             deleteComment={async (commentId, setDeleteLoading) => {
-              setDeleteLoading(true)
-              await ghAPIV4.deleteComment({ accessToken: token, commentId, issueId: issue.id })
-              updateComments()
-              setDeleteLoading(false)
+              setDeleteLoading(true);
+              await ghAPIV4.deleteComment({ accessToken: token, commentId, issueId: issue.id });
+              updateComments();
+              setDeleteLoading(false);
             }}
             addReaction={async (commentId, reaction) => {
-              await ghAPIV4.postCommentReaction({ accessToken: token, commentId, reaction, issueId: issue.id })
+              await ghAPIV4.postCommentReaction({ accessToken: token, commentId, reaction, issueId: issue.id });
             }}
             removeReaction={async (commentId, reaction) => {
-              await ghAPIV4.deleteCommentReaction({ accessToken: token, commentId, reaction, issueId: issue.id })
+              await ghAPIV4.deleteCommentReaction({ accessToken: token, commentId, reaction, issueId: issue.id });
             }}
           />
         ))
       }
     </InputContentProvider>
-  )
-}
+  );
+};
 
-export default CommentComponent
+export default CommentComponent;

--- a/gatsby-theme-oi-wiki/src/components/Comment/CommentInput.tsx
+++ b/gatsby-theme-oi-wiki/src/components/Comment/CommentInput.tsx
@@ -1,6 +1,6 @@
-import React, { useState } from 'react'
-import { makeStyles, Avatar, TextField, Grid, Button, Hidden, LinearProgress } from '@material-ui/core'
-import { useInputContentContext } from './inputContext'
+import React, { useState } from 'react';
+import { makeStyles, Avatar, TextField, Grid, Button, Hidden, LinearProgress } from '@material-ui/core';
+import { useInputContentContext } from './inputContext';
 
 interface Props {
   avatarLink: string,
@@ -34,12 +34,12 @@ const useStyles = makeStyles(theme => ({
     textAlign: 'right',
     marginBottom: theme.spacing(1),
   },
-}))
+}));
 
 const CommentInput: React.FC<Props> = (props) => {
-  const classes = useStyles()
-  const { inputContent, setInputContent } = useInputContentContext()
-  const [loading, setLoading] = useState<boolean>(false)
+  const classes = useStyles();
+  const { inputContent, setInputContent } = useInputContentContext();
+  const [loading, setLoading] = useState<boolean>(false);
   return (
     <>
       {loading && <LinearProgress />}
@@ -57,7 +57,7 @@ const CommentInput: React.FC<Props> = (props) => {
             disabled={!props.authorized || loading}
             rows={5}
             value={inputContent}
-            onChange={(e) => { setInputContent(e.target.value) }}
+            onChange={(e) => { setInputContent(e.target.value); }}
             variant="outlined"
           />
         </Grid>
@@ -71,17 +71,17 @@ const CommentInput: React.FC<Props> = (props) => {
           // disabled={loading && props.showLogin ? false : !props.authorized}
           onClick={() => {
             if (props.showLogin) {
-              props.handleLogin()
+              props.handleLogin();
             } else {
-              props.sendComment(inputContent, setLoading)
-              setInputContent('')
+              props.sendComment(inputContent, setLoading);
+              setInputContent('');
             }
           }}>
           {props.showLogin ? '登录' : '评论'}
         </Button>
       </div>
     </>
-  )
-}
+  );
+};
 
-export default CommentInput
+export default CommentInput;

--- a/gatsby-theme-oi-wiki/src/components/Comment/api.ts
+++ b/gatsby-theme-oi-wiki/src/components/Comment/api.ts
@@ -1,23 +1,23 @@
-import GithubV3 from '@mgtd/vssue-api-github-v3'
-import GithubV4 from '@mgtd/vssue-api-github-v4'
-import { Comments, Issue } from './types'
+import GithubV3 from '@mgtd/vssue-api-github-v3';
+import GithubV4 from '@mgtd/vssue-api-github-v4';
+import { Comments, Issue } from './types';
 
 export async function getComments (ghAPIV3: GithubV3, ghAPIV4: GithubV4, id: string, revokeToken: () => void, token?: string): Promise<[Issue, Comments] | 'noIssue' | 'invalidToken'> {
-  let issue: Issue
+  let issue: Issue;
   try {
-    issue = await ghAPIV3.getIssue({ accessToken: token, issueTitle: id })
+    issue = await ghAPIV3.getIssue({ accessToken: token, issueTitle: id });
   } catch (e) {
-    revokeToken()
-    return 'invalidToken'
+    revokeToken();
+    return 'invalidToken';
   }
   if (issue === null) {
-    return 'noIssue'
+    return 'noIssue';
   }
-  let comments: Comments
+  let comments: Comments;
   if (!token) {
-    comments = await ghAPIV3.getComments({ accessToken: token, issueId: issue.id, query: { page: 1, perPage: 100 } })
+    comments = await ghAPIV3.getComments({ accessToken: token, issueId: issue.id, query: { page: 1, perPage: 100 } });
   } else {
-    comments = await ghAPIV4.getComments({ accessToken: token, issueId: issue.id, query: { page: 1, perPage: 100, sort: 'asce' } })
+    comments = await ghAPIV4.getComments({ accessToken: token, issueId: issue.id, query: { page: 1, perPage: 100, sort: 'asce' } });
   }
-  return [issue, comments]
+  return [issue, comments];
 }

--- a/gatsby-theme-oi-wiki/src/components/Comment/index.tsx
+++ b/gatsby-theme-oi-wiki/src/components/Comment/index.tsx
@@ -1,7 +1,7 @@
-import { Accordion, AccordionDetails, AccordionSummary, Container, makeStyles, Typography } from '@material-ui/core'
-import { ExpandMore as ExpandMoreIcon, Forum as ForumIcon } from '@material-ui/icons'
-import React from 'react'
-import CommentComponent from './Comment'
+import { Accordion, AccordionDetails, AccordionSummary, Container, makeStyles, Typography } from '@material-ui/core';
+import { ExpandMore as ExpandMoreIcon, Forum as ForumIcon } from '@material-ui/icons';
+import React from 'react';
+import CommentComponent from './Comment';
 
 export interface CommentSystemProps {
   title: string
@@ -29,16 +29,16 @@ const CommentSystem: React.FC<CommentSystemProps> = ({ title }) => (
     clientID={process.env.GATSBY_GITHUB_CLIENT_ID || ''}
     clientSecret={process.env.GATSBY_GITHUB_CLIENT_SECRET || ''}
   />
-)
+);
 
 const useStyles = makeStyles({
   metaIcon: {
     verticalAlign: 'sub',
   },
-})
+});
 
 const Comment: React.FC<CommentComponentProps> = ({ title }) => {
-  const classes = useStyles()
+  const classes = useStyles();
   return (
     <Accordion variant="outlined" defaultExpanded>
       <AccordionSummary
@@ -53,7 +53,7 @@ const Comment: React.FC<CommentComponentProps> = ({ title }) => {
         </Container>
       </AccordionDetails>
     </Accordion>
-  )
-}
+  );
+};
 
-export default Comment
+export default Comment;

--- a/gatsby-theme-oi-wiki/src/components/Comment/inputContext.ts
+++ b/gatsby-theme-oi-wiki/src/components/Comment/inputContext.ts
@@ -1,9 +1,9 @@
-import { useState } from 'react'
-import constate from 'constate'
+import { useState } from 'react';
+import constate from 'constate';
 
 const [InputContentProvider, useInputContentContext] = constate(() => {
-  const [inputContent, setInputContent] = useState('')
-  return { inputContent, setInputContent }
-})
+  const [inputContent, setInputContent] = useState('');
+  return { inputContent, setInputContent };
+});
 
-export { InputContentProvider, useInputContentContext }
+export { InputContentProvider, useInputContentContext };

--- a/gatsby-theme-oi-wiki/src/components/Comment/types.ts
+++ b/gatsby-theme-oi-wiki/src/components/Comment/types.ts
@@ -1,4 +1,4 @@
-import { Comments, Reactions } from '@mgtd/vssue-api-github-v4/lib/types'
+import { Comments, Reactions } from '@mgtd/vssue-api-github-v4/lib/types';
 
 export interface User {
   avatar: string,
@@ -13,4 +13,4 @@ export interface Issue {
   link: string
 }
 
-export { Comments, Reactions }
+export { Comments, Reactions };

--- a/gatsby-theme-oi-wiki/src/components/Details.tsx
+++ b/gatsby-theme-oi-wiki/src/components/Details.tsx
@@ -1,6 +1,6 @@
-import { Accordion, AccordionDetails } from '@material-ui/core'
-import { makeStyles } from '@material-ui/core/styles'
-import React from 'react'
+import { Accordion, AccordionDetails } from '@material-ui/core';
+import { makeStyles } from '@material-ui/core/styles';
+import React from 'react';
 
 const getDetailsClasses = makeStyles((theme) => ({
   root: {
@@ -16,7 +16,7 @@ const getDetailsClasses = makeStyles((theme) => ({
       margin: '1.2em 0 !important',
     },
   },
-}))
+}));
 
 const useStyles = makeStyles(theme => ({
   container: {
@@ -24,7 +24,7 @@ const useStyles = makeStyles(theme => ({
     marginLeft: theme.spacing(2),
     marginRight: theme.spacing(2),
   },
-}))
+}));
 
 export interface DetailsProps {
   className: string;
@@ -32,10 +32,10 @@ export interface DetailsProps {
 }
 
 const Details: React.FC<DetailsProps> = (props) => {
-  const { className = '', children } = props
-  const detailsClasses = getDetailsClasses()
-  const classes = useStyles()
-  const cont = Array.isArray(children) ? children : [children]
+  const { className = '', children } = props;
+  const detailsClasses = getDetailsClasses();
+  const classes = useStyles();
+  const cont = Array.isArray(children) ? children : [children];
   return (
     <Accordion
       variant="outlined"
@@ -47,7 +47,7 @@ const Details: React.FC<DetailsProps> = (props) => {
         <div className={classes.container}>{cont.slice(1)}</div>
       </AccordionDetails>
     </Accordion>
-  )
-}
+  );
+};
 
-export default Details
+export default Details;

--- a/gatsby-theme-oi-wiki/src/components/EditWarn.tsx
+++ b/gatsby-theme-oi-wiki/src/components/EditWarn.tsx
@@ -1,7 +1,7 @@
-import { Button, Dialog, DialogActions, DialogContent, DialogTitle } from '@material-ui/core'
+import { Button, Dialog, DialogActions, DialogContent, DialogTitle } from '@material-ui/core';
 
-import React from 'react'
-import { SmartLink } from './Link'
+import React from 'react';
+import { SmartLink } from './Link';
 
 const EditWarning = (): JSX.Element => {
   return (
@@ -14,8 +14,8 @@ const EditWarning = (): JSX.Element => {
       </p>
       <p>在阅读完之后，请点击下方的按钮，然后开始编辑。</p>
     </>
-  )
-}
+  );
+};
 
 export interface EditWarnProps {
   relativePath: string;
@@ -25,11 +25,11 @@ export interface EditWarnProps {
 }
 
 const EditWarn: React.FC<EditWarnProps> = (props) => {
-  const { relativePath, dialogOpen, setDialogOpen } = props
-  const editURL = 'https://github.com/OI-wiki/OI-wiki/edit/master/docs/'
+  const { relativePath, dialogOpen, setDialogOpen } = props;
+  const editURL = 'https://github.com/OI-wiki/OI-wiki/edit/master/docs/';
   const onClose = (): void => {
-    setDialogOpen(false)
-  }
+    setDialogOpen(false);
+  };
 
   return (
     <Dialog
@@ -53,7 +53,7 @@ const EditWarn: React.FC<EditWarnProps> = (props) => {
         </Button>
       </DialogActions>
     </Dialog>
-  )
-}
+  );
+};
 
-export default EditWarn
+export default EditWarn;

--- a/gatsby-theme-oi-wiki/src/components/Footer.tsx
+++ b/gatsby-theme-oi-wiki/src/components/Footer.tsx
@@ -1,19 +1,19 @@
-import { Typography } from '@material-ui/core'
-import { makeStyles } from '@material-ui/core/styles'
-import { graphql, useStaticQuery } from 'gatsby'
-import React, { useEffect } from 'react'
-import { SmartLink } from './Link'
+import { Typography } from '@material-ui/core';
+import { makeStyles } from '@material-ui/core/styles';
+import { graphql, useStaticQuery } from 'gatsby';
+import React, { useEffect } from 'react';
+import { SmartLink } from './Link';
 
 const useStyles = makeStyles((theme) => ({
   link: {
     color: theme.palette.footer.text,
   },
-}))
+}));
 
-let eggShowed = false
+let eggShowed = false;
 
 const Footer: React.FC = () => {
-  const classes = useStyles()
+  const classes = useStyles();
   const data = useStaticQuery<GatsbyTypes.lastestCommitQuery>(graphql`
     query lastestCommit {
       allGitCommit(limit: 1) {
@@ -23,20 +23,20 @@ const Footer: React.FC = () => {
         }
       }
     }
-  `)
+  `);
 
-  const { date, hash } = data.allGitCommit.nodes[0]
-  const hashFrag = hash?.substr(0, 7)
-  const dateStr = date?.toString()
+  const { date, hash } = data.allGitCommit.nodes[0];
+  const hashFrag = hash?.substr(0, 7);
+  const dateStr = date?.toString();
 
   useEffect(() => {
     if (typeof window !== 'undefined' && !eggShowed) {
-      const SchoolIcon = 'background: url("data:image/svg+xml;utf8,<svg xmlns=\'http://www.w3.org/2000/svg\'><path transform=\'translate(0 12) scale(6)\' d=\'M5 13.18v4L12 21l7-3.82v-4L12 17l-7-3.82zM12 3L1 9l11 6 9-4.91V17h2V9L12 3z\'/></svg>")'
-      console.log(`%cOI Wiki %c ${hashFrag} `, `${SchoolIcon}; font-size: 1.5em; padding: 10em 5em 1em 0;`, 'background:#41b883; margin-left: -7.5em; padding: .2em; border-radius: 3px; color: #fff;')
-      console.log('%c少年，恭喜你发现彩蛋一枚。我们在做一些 OI 相关的有趣的事情。\n如果您对此感兴趣，欢迎访问 https://join-us.oi-wiki.org', 'font-size: 1.4em; line-height: 1.5;')
-      eggShowed = true
+      const SchoolIcon = 'background: url("data:image/svg+xml;utf8,<svg xmlns=\'http://www.w3.org/2000/svg\'><path transform=\'translate(0 12) scale(6)\' d=\'M5 13.18v4L12 21l7-3.82v-4L12 17l-7-3.82zM12 3L1 9l11 6 9-4.91V17h2V9L12 3z\'/></svg>")';
+      console.log(`%cOI Wiki %c ${hashFrag} `, `${SchoolIcon}; font-size: 1.5em; padding: 10em 5em 1em 0;`, 'background:#41b883; margin-left: -7.5em; padding: .2em; border-radius: 3px; color: #fff;');
+      console.log('%c少年，恭喜你发现彩蛋一枚。我们在做一些 OI 相关的有趣的事情。\n如果您对此感兴趣，欢迎访问 https://join-us.oi-wiki.org', 'font-size: 1.4em; line-height: 1.5;');
+      eggShowed = true;
     }
-  }, [hash, hashFrag])
+  }, [hash, hashFrag]);
 
   return (
     <>
@@ -60,7 +60,7 @@ const Footer: React.FC = () => {
         </SmartLink>
       </Typography>
     </>
-  )
-}
+  );
+};
 
-export default Footer
+export default Footer;

--- a/gatsby-theme-oi-wiki/src/components/Indicator.tsx
+++ b/gatsby-theme-oi-wiki/src/components/Indicator.tsx
@@ -1,6 +1,6 @@
-import { makeStyles, Typography } from '@material-ui/core'
-import clsx from 'clsx'
-import React from 'react'
+import { makeStyles, Typography } from '@material-ui/core';
+import clsx from 'clsx';
+import React from 'react';
 
 const useStyles = makeStyles((theme) => ({
   indicator: {
@@ -21,7 +21,7 @@ const useStyles = makeStyles((theme) => ({
   error: {
     background: theme.palette.error.main,
   },
-}))
+}));
 
 export interface IndicatorProps {
   type: 'info' | 'success' | 'error' | 'warning' | undefined
@@ -29,7 +29,7 @@ export interface IndicatorProps {
 }
 
 const Indicator: React.FC<IndicatorProps> = ({ type, msg }: IndicatorProps) => {
-  const classes = useStyles()
+  const classes = useStyles();
   return (
     <Typography
       className={clsx(classes.indicator, {
@@ -41,7 +41,7 @@ const Indicator: React.FC<IndicatorProps> = ({ type, msg }: IndicatorProps) => {
     >
       {msg}
     </Typography>
-  )
-}
+  );
+};
 
-export default Indicator
+export default Indicator;

--- a/gatsby-theme-oi-wiki/src/components/Link/LinkTooltip.tsx
+++ b/gatsby-theme-oi-wiki/src/components/Link/LinkTooltip.tsx
@@ -1,7 +1,7 @@
-import React, { useState } from 'react'
-import ToolCard from './ToolCard'
-import { useDidUpdateEffect } from './hooks'
-import { Nullable } from '../../types/common'
+import React, { useState } from 'react';
+import ToolCard from './ToolCard';
+import { useDidUpdateEffect } from './hooks';
+import { Nullable } from '../../types/common';
 
 export interface PreviewData {
   text: string,
@@ -18,32 +18,32 @@ export interface LinkTooltipProps {
 export type FetchStatus = 'error' | 'fetching' | 'fetched' | 'not_fetched'
 
 async function getExcerpt(url: string): Promise<PreviewData> {
-  return await fetch(url).then(res => res.json())
+  return await fetch(url).then(res => res.json());
 }
 
 const LinkTooltip: React.FC<LinkTooltipProps> = (props) => {
-  const { url, children } = props
-  const [content, setContent] = useState<Nullable<PreviewData>>(null)
-  const [status, setStatus] = useState<FetchStatus>('not_fetched')
-  const [open, setOpen] = useState<boolean>()
+  const { url, children } = props;
+  const [content, setContent] = useState<Nullable<PreviewData>>(null);
+  const [status, setStatus] = useState<FetchStatus>('not_fetched');
+  const [open, setOpen] = useState<boolean>();
 
   useDidUpdateEffect(() => {
     if (status === 'not_fetched') {
       // 防止重复获取
-      setStatus('fetching')
+      setStatus('fetching');
       getExcerpt(url).then(data => {
-        setContent(data)
-        setStatus('fetched')
+        setContent(data);
+        setStatus('fetched');
       }).catch(e => {
-        console.error(e)
-        setStatus('error')
-      })
+        console.error(e);
+        setStatus('error');
+      });
     }
-  }, [open])
+  }, [open]);
 
   return <ToolCard
     onHover={() => {
-      setOpen(true)
+      setOpen(true);
     }}
     content={content}
     to={props.to}
@@ -52,7 +52,7 @@ const LinkTooltip: React.FC<LinkTooltipProps> = (props) => {
     openDelay={500}
   >
     {children}
-  </ToolCard>
-}
+  </ToolCard>;
+};
 
-export default LinkTooltip
+export default LinkTooltip;

--- a/gatsby-theme-oi-wiki/src/components/Link/ToolCard.tsx
+++ b/gatsby-theme-oi-wiki/src/components/Link/ToolCard.tsx
@@ -1,16 +1,16 @@
-import React, { createRef, useCallback, useEffect, useRef, useState } from 'react'
-import { Card, CardContent, CircularProgress, Fade, makeStyles } from '@material-ui/core'
-import { Link as GatsbyLink } from 'gatsby'
+import React, { createRef, useCallback, useEffect, useRef, useState } from 'react';
+import { Card, CardContent, CircularProgress, Fade, makeStyles } from '@material-ui/core';
+import { Link as GatsbyLink } from 'gatsby';
 
-import { FetchStatus, PreviewData } from './LinkTooltip'
-import { useDelay } from './hooks'
-import { getElementSize, getElementViewPosition, Position, Size } from './utils'
-import { Nullable } from '../../types/common'
-import { Alert } from '@material-ui/lab'
+import { FetchStatus, PreviewData } from './LinkTooltip';
+import { useDelay } from './hooks';
+import { getElementSize, getElementViewPosition, Position, Size } from './utils';
+import { Nullable } from '../../types/common';
+import { Alert } from '@material-ui/lab';
 
-const lines = 4
-const lineHeight = 1.5
-const cardDis = '2rem'
+const lines = 4;
+const lineHeight = 1.5;
+const cardDis = '2rem';
 const useStyles = makeStyles((theme) => ({
   container: {
     position: 'relative',
@@ -49,7 +49,7 @@ const useStyles = makeStyles((theme) => ({
     justifyContent: 'center',
     alignItems: 'center',
   },
-}))
+}));
 
 interface PositionAndSize {
   pos: Position,
@@ -68,73 +68,73 @@ export interface ToolCardProps {
 }
 
 const ToolCard: React.FC<ToolCardProps> = (props) => {
-  const classes = useStyles()
-  const { children, content, status, closeDelay = 0, openDelay = 0, onHover, to } = props
-  const [open, setOpen] = useState(false)
-  const rootRef = createRef<HTMLDivElement>()
-  const popperRef = useRef<HTMLElement>()
+  const classes = useStyles();
+  const { children, content, status, closeDelay = 0, openDelay = 0, onHover, to } = props;
+  const [open, setOpen] = useState(false);
+  const rootRef = createRef<HTMLDivElement>();
+  const popperRef = useRef<HTMLElement>();
   const [onOpen, onClose] = useDelay(() => {
-    setOpen(true)
-    props.onOpen?.()
+    setOpen(true);
+    props.onOpen?.();
   }, () => {
-    setOpen(false)
-  }, openDelay, closeDelay)
+    setOpen(false);
+  }, openDelay, closeDelay);
 
   const adjustElementPosition = useCallback((element: HTMLElement, { pos, size }: PositionAndSize): void => {
-    if (!element || !rootRef.current) return
+    if (!element || !rootRef.current) return;
 
     const viewport = {
       width: window?.innerWidth || document.documentElement.clientWidth,
       height: window?.innerHeight || document.documentElement.clientHeight,
-    }
-    const betterDis = 20
+    };
+    const betterDis = 20;
 
-    let left, right
+    let left, right;
 
     // On the left half of the screen
     if (pos.x < viewport.width / 2) {
-      const cardRightX = pos.x + size.width
-      const toRight = viewport.width - cardRightX - betterDis
+      const cardRightX = pos.x + size.width;
+      const toRight = viewport.width - cardRightX - betterDis;
       if (toRight >= 0) {
-        left = 0
+        left = 0;
       } else {
-        const gap = pos.x + toRight
-        left = gap >= 0 ? toRight : gap
+        const gap = pos.x + toRight;
+        left = gap >= 0 ? toRight : gap;
       }
     } else {
-      const { width } = getElementSize(rootRef.current)
-      const rootRightX = pos.x + width
-      const toLeft = rootRightX - size.width - betterDis
+      const { width } = getElementSize(rootRef.current);
+      const rootRightX = pos.x + width;
+      const toLeft = rootRightX - size.width - betterDis;
       if (toLeft >= 0) {
-        right = 0
+        right = 0;
       } else {
-        const gap = viewport.width + toLeft
-        right = gap >= 0 ? toLeft : gap
+        const gap = viewport.width + toLeft;
+        right = gap >= 0 ? toLeft : gap;
       }
     }
 
-    element.style.setProperty('right', typeof right === 'undefined' ? 'auto' : `${right}px`)
-    element.style.setProperty('left', typeof left === 'undefined' ? 'auto' : `${left}px`)
-    element.classList.toggle(classes.aboveMedian, pos.y > viewport.height / 2)
+    element.style.setProperty('right', typeof right === 'undefined' ? 'auto' : `${right}px`);
+    element.style.setProperty('left', typeof left === 'undefined' ? 'auto' : `${left}px`);
+    element.classList.toggle(classes.aboveMedian, pos.y > viewport.height / 2);
 
-  }, [classes.aboveMedian, rootRef])
+  }, [classes.aboveMedian, rootRef]);
 
   useEffect(() => {
     if (open && popperRef.current) {
       const data: PositionAndSize = {
         pos: getElementViewPosition(popperRef.current.parentElement as HTMLElement),
         size: getElementSize(popperRef.current),
-      }
-      adjustElementPosition(popperRef.current, data)
+      };
+      adjustElementPosition(popperRef.current, data);
     }
-  }, [open, content, popperRef, adjustElementPosition, rootRef])
+  }, [open, content, popperRef, adjustElementPosition, rootRef]);
 
   return (
     <span
       className={classes.container}
       onMouseEnter={() => {
-        onOpen()
-        onHover?.()
+        onOpen();
+        onHover?.();
       }}
       onMouseLeave={onClose}
       ref={rootRef}
@@ -152,16 +152,16 @@ const ToolCard: React.FC<ToolCardProps> = (props) => {
               if (status === 'not_fetched' || status === 'fetching') {
                 return <CardContent className={classes.fetching}>
                   <CircularProgress/>
-                </CardContent>
+                </CardContent>;
               } else if (status === 'fetched') {
                 return <CardContent>
                   <div className={classes.fade}>
                     <strong>{content?.title + ' '}</strong>
                     {content?.text}
                   </div>
-                </CardContent>
+                </CardContent>;
               } else {
-                return <Alert severity="error">无法获取页面预览</Alert>
+                return <Alert severity="error">无法获取页面预览</Alert>;
               }
             })()}
           </Card>
@@ -169,7 +169,7 @@ const ToolCard: React.FC<ToolCardProps> = (props) => {
       </GatsbyLink>
       {children}
     </span>
-  )
-}
+  );
+};
 
-export default ToolCard
+export default ToolCard;

--- a/gatsby-theme-oi-wiki/src/components/Link/hooks.tsx
+++ b/gatsby-theme-oi-wiki/src/components/Link/hooks.tsx
@@ -1,59 +1,59 @@
-import React, { useEffect, useRef } from 'react'
-import { Nullable } from '../../types/common'
+import React, { useEffect, useRef } from 'react';
+import { Nullable } from '../../types/common';
 
 export function useDidUpdateEffect(fn: (...args: any) => void, inputs: React.DependencyList): void {
-  const didMountRef = useRef(false)
-  const fnRef = useRef(fn)
+  const didMountRef = useRef(false);
+  const fnRef = useRef(fn);
 
   useEffect(() => {
-    if (didMountRef.current) fnRef.current()
-    else didMountRef.current = true
+    if (didMountRef.current) fnRef.current();
+    else didMountRef.current = true;
     // eslint-disable-next-line react-hooks/exhaustive-deps
-  }, inputs)
+  }, inputs);
 }
 
 export function useDelay(onOpen: () => void, onClose: () => void, openDelay: number, closeDelay: number): [() => void, () => void] {
-  const closeHandle = useRef<Nullable<NodeJS.Timeout>>()
-  const openHandle = useRef<Nullable<NodeJS.Timeout>>()
+  const closeHandle = useRef<Nullable<NodeJS.Timeout>>();
+  const openHandle = useRef<Nullable<NodeJS.Timeout>>();
 
   const clearClose = (): void => {
     if (closeHandle.current) {
-      clearTimeout(closeHandle.current)
-      closeHandle.current = null
+      clearTimeout(closeHandle.current);
+      closeHandle.current = null;
     }
-  }
+  };
 
   const clearOpen = (): void => {
     if (openHandle.current) {
-      clearTimeout(openHandle.current)
-      openHandle.current = null
+      clearTimeout(openHandle.current);
+      openHandle.current = null;
     }
-  }
+  };
 
   function open(): void {
     // 正在准备close，则不让它close
-    clearClose()
+    clearClose();
 
     // 如果之前没有 open 事件就创建一个
     if (!openHandle.current) {
       openHandle.current = setTimeout(() => {
-        onOpen()
-        clearOpen()
-      }, openDelay)
+        onOpen();
+        clearOpen();
+      }, openDelay);
     }
   }
 
   function close(): void {
     // 之前的 close 事件需要被清除
-    clearClose()
+    clearClose();
     // 鼠标快进快出，则不显示
-    clearOpen()
+    clearOpen();
 
     closeHandle.current = setTimeout(() => {
-      onClose()
-      clearClose()
-    }, closeDelay)
+      onClose();
+      clearClose();
+    }, closeDelay);
   }
 
-  return [open, close]
+  return [open, close];
 }

--- a/gatsby-theme-oi-wiki/src/components/Link/index.tsx
+++ b/gatsby-theme-oi-wiki/src/components/Link/index.tsx
@@ -1,18 +1,18 @@
-import { makeStyles } from '@material-ui/core/styles'
-import { Link as GatsbyLink } from 'gatsby'
-import isAbsoluteURL from 'is-absolute-url'
-import React from 'react'
-import LinkTooltip from './LinkTooltip'
-import path from 'path'
-import clsx from 'clsx'
-import { GatsbyLinkProps } from 'gatsby-link'
-import smoothScrollTo from '../../lib/smoothScroll'
-import { useSetting } from '../../lib/useSetting'
-import { useMediaQuery, useTheme } from '@material-ui/core'
-import { OnClickHandler } from '../../types/common'
+import { makeStyles } from '@material-ui/core/styles';
+import { Link as GatsbyLink } from 'gatsby';
+import isAbsoluteURL from 'is-absolute-url';
+import React from 'react';
+import LinkTooltip from './LinkTooltip';
+import path from 'path';
+import clsx from 'clsx';
+import { GatsbyLinkProps } from 'gatsby-link';
+import smoothScrollTo from '../../lib/smoothScroll';
+import { useSetting } from '../../lib/useSetting';
+import { useMediaQuery, useTheme } from '@material-ui/core';
+import { OnClickHandler } from '../../types/common';
 
-const MD_EXPR = /\.(md|markdown|mdtext|mdx)/g
-const NO_SLASH_EXPR = /[^/]$/
+const MD_EXPR = /\.(md|markdown|mdtext|mdx)/g;
+const NO_SLASH_EXPR = /[^/]$/;
 
 /**
  * 修复相对路径的页面链接
@@ -28,27 +28,27 @@ const NO_SLASH_EXPR = /[^/]$/
  * 实际上不需要当前页面的 path
  */
 const linkFix = (link: string, isIndex: boolean): string => {
-  if (/^\//.test(link)) return link // absolute path
+  if (/^\//.test(link)) return link; // absolute path
 
-  let newLink = link.replace(MD_EXPR, '/').replace('index', '')
-  if (!isIndex) newLink = '../' + newLink
+  let newLink = link.replace(MD_EXPR, '/').replace('index', '');
+  if (!isIndex) newLink = '../' + newLink;
   if (NO_SLASH_EXPR.test(newLink) && !/#/.test(newLink)) {
-    newLink += '/' // append '/' for links, but excluding urls includes `#`.
+    newLink += '/'; // append '/' for links, but excluding urls includes `#`.
   }
-  return newLink
-}
+  return newLink;
+};
 
 const getAPILink = (link: string, pathname: string, isIndex: boolean): string => {
-  let newLink = link.replace(MD_EXPR, '/').replace(/#(.*?)$/, '')
+  let newLink = link.replace(MD_EXPR, '/').replace(/#(.*?)$/, '');
   if (/^[^/]/.test(newLink)) {
-    if (!isIndex) newLink = '../' + newLink
-    if (NO_SLASH_EXPR.test(pathname)) pathname += '/'
-    newLink = path.resolve(pathname, newLink)
+    if (!isIndex) newLink = '../' + newLink;
+    if (NO_SLASH_EXPR.test(pathname)) pathname += '/';
+    newLink = path.resolve(pathname, newLink);
   }
-  return `https://api.mgt.moe/preview?path=${newLink}`
-}
+  return `https://api.mgt.moe/preview?path=${newLink}`;
+};
 
-const isRef = (link: string): boolean => /^#/.test(link)
+const isRef = (link: string): boolean => /^#/.test(link);
 
 const useStyles = makeStyles((theme) => ({
   link: {
@@ -60,7 +60,7 @@ const useStyles = makeStyles((theme) => ({
     },
     transition: `color ${250}ms ease-in-out`,
   },
-}))
+}));
 
 export interface SmartLinkProps<T = any> extends Omit<GatsbyLinkProps<T>, 'to'> {
   /** 指向的链接 */
@@ -86,8 +86,8 @@ export interface SmartLinkProps<T = any> extends Omit<GatsbyLinkProps<T>, 'to'> 
  * - 如果是 path 则根据 tooltip 属性决定是否启用 Tooltip
  */
 const SmartLink: React.FC<SmartLinkProps> = (props) => {
-  const theme = useTheme()
-  const classes = useStyles()
+  const theme = useTheme();
+  const classes = useStyles();
 
   const {
     tooltip = false,
@@ -98,58 +98,58 @@ const SmartLink: React.FC<SmartLinkProps> = (props) => {
     pathname,
     children,
     ...others
-  } = props
-  const classList = clsx(className, classes.link)
-  const [settings] = useSetting()
-  const isMdDown = useMediaQuery(theme.breakpoints.down('md'))
-  const href = to || link || ''
+  } = props;
+  const classList = clsx(className, classes.link);
+  const [settings] = useSetting();
+  const isMdDown = useMediaQuery(theme.breakpoints.down('md'));
+  const href = to || link || '';
 
   if (className && className.search('anchor') > -1) {
-    return <a {...others} href={href}>{children}</a>
+    return <a {...others} href={href}>{children}</a>;
   } else if (isAbsoluteURL(href)) {
     return (
       <a {...others} href={href} className={classList} target="_blank" rel="noopener noreferrer nofollow">
         {children}
       </a>
-    )
+    );
   } else if (isRef(href)) {
-    const tabHeight = isMdDown ? 64 : 112
-    const scrollPadding = 24
+    const tabHeight = isMdDown ? 64 : 112;
+    const scrollPadding = 24;
 
     const onClick: OnClickHandler = (e) => {
-      e.preventDefault()
+      e.preventDefault();
 
-      const target = document.getElementById(href.substring(1, href.length))
-      const yDis = (target?.getBoundingClientRect().top as number) + window?.pageYOffset - tabHeight - scrollPadding
+      const target = document.getElementById(href.substring(1, href.length));
+      const yDis = (target?.getBoundingClientRect().top as number) + window?.pageYOffset - tabHeight - scrollPadding;
 
       if (settings.animation.smoothScroll) {
-        smoothScrollTo(yDis)
+        smoothScrollTo(yDis);
       } else {
-        window?.scrollTo(0, yDis)
+        window?.scrollTo(0, yDis);
       }
-    }
+    };
 
     return (
       <GatsbyLink {...others as any} to={href} className={classList} onClick={onClick}>
         {children}
       </GatsbyLink>
-    )
+    );
   } else if (tooltip) {
-    if (!pathname) throw new Error('tooltip 为 true 时必须给出 pathname')
+    if (!pathname) throw new Error('tooltip 为 true 时必须给出 pathname');
     return (
       <LinkTooltip url={getAPILink(href, pathname, isIndex)} to={linkFix(href, isIndex)}>
         <GatsbyLink {...others as any} to={linkFix(href, isIndex)} className={classList}>
           {children}
         </GatsbyLink>
       </LinkTooltip>
-    )
+    );
   } else {
     return (
       <GatsbyLink {...others as any} to={linkFix(href, isIndex)} className={classList}>
         {children}
       </GatsbyLink>
-    )
+    );
   }
-}
+};
 
-export { SmartLink }
+export { SmartLink };

--- a/gatsby-theme-oi-wiki/src/components/Link/utils.ts
+++ b/gatsby-theme-oi-wiki/src/components/Link/utils.ts
@@ -4,12 +4,12 @@ export type Position = Pick<DOMRect, 'x' | 'y'>
  * 获取元素的绝对位置坐标（相对于浏览器视区左上角）
  */
 export const getElementViewPosition = (el: HTMLElement): Position => {
-  const rect = el.getBoundingClientRect()
+  const rect = el.getBoundingClientRect();
   return {
     x: rect.x || rect.top,
     y: rect.y || rect.bottom,
-  }
-}
+  };
+};
 
 export type Size = Pick<DOMRect, 'width' | 'height'>
 
@@ -17,5 +17,5 @@ export function getElementSize(el: HTMLElement): Size {
   return {
     width: el.offsetWidth,
     height: el.offsetHeight,
-  }
+  };
 }

--- a/gatsby-theme-oi-wiki/src/components/Mdx.tsx
+++ b/gatsby-theme-oi-wiki/src/components/Mdx.tsx
@@ -1,16 +1,16 @@
-import React, { useCallback, useEffect } from 'react'
-import Mark from 'mark.js'
-import clsx from 'clsx'
+import React, { useCallback, useEffect } from 'react';
+import Mark from 'mark.js';
+import clsx from 'clsx';
 
-import MDRenderer from '../lib/MDRenderer'
-import Details from './Details'
-import Summary from './Summary'
-import Codetab from './Codetab'
-import { SmartLink, SmartLinkProps } from './Link'
-import SEO from './Seo'
-import StyledLayout from './StyledLayout'
-import { DeepRequiredNonNull, DeepWriteable, Nullable } from '../types/common'
-import Code from './Code'
+import MDRenderer from '../lib/MDRenderer';
+import Details from './Details';
+import Summary from './Summary';
+import Codetab from './Codetab';
+import { SmartLink, SmartLinkProps } from './Link';
+import SEO from './Seo';
+import StyledLayout from './StyledLayout';
+import { DeepRequiredNonNull, DeepWriteable, Nullable } from '../types/common';
+import Code from './Code';
 
 export interface MdxProps {
   data: DeepWriteable<DeepRequiredNonNull<GatsbyTypes.DocQuery>>
@@ -18,57 +18,57 @@ export interface MdxProps {
 }
 
 const Mdx: React.FC<MdxProps> = ({ data: { mdx }, location }) => {
-  const title = mdx.fields.slug === '/' ? '' : mdx.frontmatter.title
-  const description = mdx.frontmatter.description || mdx.excerpt
-  const authors = mdx.frontmatter.author || ''
-  const tags = mdx.frontmatter.tags || []
-  const noMeta = mdx.frontmatter.noMeta || false
-  const noComment = mdx.frontmatter.noComment || false
-  const noEdit = false
-  const headings = mdx.headings || null
-  const relativePath = mdx.parent.relativePath || ''
-  const modifiedTime = mdx.parent.modifiedTime || ''
-  const wordCount = mdx.wordCount.words || 0
-  const datePublished = mdx.parent.birthTime || ''
-  const dateModified = mdx.parent.changeTime || ''
-  const isIndex = mdx.fields.isIndex
+  const title = mdx.fields.slug === '/' ? '' : mdx.frontmatter.title;
+  const description = mdx.frontmatter.description || mdx.excerpt;
+  const authors = mdx.frontmatter.author || '';
+  const tags = mdx.frontmatter.tags || [];
+  const noMeta = mdx.frontmatter.noMeta || false;
+  const noComment = mdx.frontmatter.noComment || false;
+  const noEdit = false;
+  const headings = mdx.headings || null;
+  const relativePath = mdx.parent.relativePath || '';
+  const modifiedTime = mdx.parent.modifiedTime || '';
+  const wordCount = mdx.wordCount.words || 0;
+  const datePublished = mdx.parent.birthTime || '';
+  const dateModified = mdx.parent.changeTime || '';
+  const isIndex = mdx.fields.isIndex;
 
   const highlightNode = useCallback((tagName: string, isHighlight: boolean): void => {
     if (location.state?.searchKey) {
-      const mainNodes = document.getElementsByTagName('main')
-      const nodes = mainNodes[0].querySelectorAll(tagName)
-      const instance = new Mark(nodes)
+      const mainNodes = document.getElementsByTagName('main');
+      const nodes = mainNodes[0].querySelectorAll(tagName);
+      const instance = new Mark(nodes);
       instance[isHighlight ? 'mark' : 'unmark'](
         location.state.searchKey,
         {
           exclude: ['span'],
-        })
+        });
     }
-  }, [location.state?.searchKey])
+  }, [location.state?.searchKey]);
 
   useEffect(() => {
     if (location.state?.searchKey) {
-      highlightNode('h1', true)
-      highlightNode('h2', true)
-      highlightNode('h3', true)
-      highlightNode('p', true)
+      highlightNode('h1', true);
+      highlightNode('h2', true);
+      highlightNode('h3', true);
+      highlightNode('p', true);
       setTimeout(
         () => {
-          highlightNode('h1', false)
-          highlightNode('h2', false)
-          highlightNode('h3', false)
-          highlightNode('p', false)
-        }, 5000)
+          highlightNode('h1', false);
+          highlightNode('h2', false);
+          highlightNode('h3', false);
+          highlightNode('p', false);
+        }, 5000);
     }
-  }, [highlightNode, location.state?.searchKey])
+  }, [highlightNode, location.state?.searchKey]);
 
   const LinkGetter: React.FC<SmartLinkProps> = (props) =>
-    <SmartLink {...props} pathname={location.pathname} isIndex={isIndex} tooltip={true}/>
+    <SmartLink {...props} pathname={location.pathname} isIndex={isIndex} tooltip={true}/>;
 
   const InlineCode: React.FC<{ className: string, [key: string]: any }> = (props) => {
-    const { className, children, ...others } = props
-    return <code {...others} className={clsx(className, 'inline-code')}>{children}</code>
-  }
+    const { className, children, ...others } = props;
+    return <code {...others} className={clsx(className, 'inline-code')}>{children}</code>;
+  };
 
   const myComponents = {
     details: Details,
@@ -77,9 +77,9 @@ const Mdx: React.FC<MdxProps> = ({ data: { mdx }, location }) => {
     inlinecode: InlineCode,
     codeblock: Code,
     'ow-codes': Codetab,
-  }
+  };
 
-  const isWIP = wordCount === 0 || (tags?.findIndex((x: string) => x === 'WIP') >= 0)
+  const isWIP = wordCount === 0 || (tags?.findIndex((x: string) => x === 'WIP') >= 0);
 
   return (
     <StyledLayout
@@ -106,7 +106,7 @@ const Mdx: React.FC<MdxProps> = ({ data: { mdx }, location }) => {
         article/>
       <MDRenderer components={myComponents} htmlAst={mdx.htmlAst}/>
     </StyledLayout>
-  )
-}
+  );
+};
 
-export default Mdx
+export default Mdx;

--- a/gatsby-theme-oi-wiki/src/components/Meta.tsx
+++ b/gatsby-theme-oi-wiki/src/components/Meta.tsx
@@ -1,13 +1,13 @@
-import { makeStyles, Paper, Typography } from '@material-ui/core'
-import CopyrightIcon from '@material-ui/icons/Copyright'
-import EditIcon from '@material-ui/icons/Edit'
-import { Group as GroupIcon, History as HistoryIcon } from '@material-ui/icons'
-import React, { useState } from 'react'
-import { SmartLink, SmartLinkProps } from './Link'
-import Tags from './Tags'
-import EditWarn from './EditWarn'
-import { uniq } from '../utils/common'
-import Time from '../components/Time'
+import { makeStyles, Paper, Typography } from '@material-ui/core';
+import CopyrightIcon from '@material-ui/icons/Copyright';
+import EditIcon from '@material-ui/icons/Edit';
+import { Group as GroupIcon, History as HistoryIcon } from '@material-ui/icons';
+import React, { useState } from 'react';
+import { SmartLink, SmartLinkProps } from './Link';
+import Tags from './Tags';
+import EditWarn from './EditWarn';
+import { uniq } from '../utils/common';
+import Time from '../components/Time';
 
 const useStyles = makeStyles((theme: any) => ({
   metaIcon: {
@@ -30,7 +30,7 @@ const useStyles = makeStyles((theme: any) => ({
     paddingLeft: theme.spacing(1),
     display: 'inline-block',
   },
-}))
+}));
 
 export interface MetaProps {
   tags: string[];
@@ -42,19 +42,19 @@ export interface MetaProps {
 }
 
 const Meta: React.FC<MetaProps> = (props) => {
-  const { tags, relativePath, modifiedTime, location, ...rest } = props
-  const classes = useStyles()
-  const [dialogOpen, setDialogOpen] = useState(false)
+  const { tags, relativePath, modifiedTime, location, ...rest } = props;
+  const classes = useStyles();
+  const [dialogOpen, setDialogOpen] = useState(false);
 
   const Author: React.FC<{ name: string }> = ({ name }) =>
     <SmartLink href={`https://github.com/${name}`} className={classes.authorLink}>
       {`@${name}`}
-    </SmartLink>
+    </SmartLink>;
 
   const click: SmartLinkProps['onClick'] = (e) => {
-    e.preventDefault()
-    setDialogOpen(true)
-  }
+    e.preventDefault();
+    setDialogOpen(true);
+  };
 
   return <>
     <EditWarn relativePath={relativePath} dialogOpen={dialogOpen} setDialogOpen={setDialogOpen} location={location}/>
@@ -105,7 +105,7 @@ const Meta: React.FC<MetaProps> = (props) => {
         </Typography>
       </div>
     </Paper>
-  </>
-}
+  </>;
+};
 
-export default Meta
+export default Meta;

--- a/gatsby-theme-oi-wiki/src/components/NavAndDrawer/NavBtnGroup.tsx
+++ b/gatsby-theme-oi-wiki/src/components/NavAndDrawer/NavBtnGroup.tsx
@@ -1,22 +1,22 @@
-import type { IconButtonProps } from '@material-ui/core'
-import { IconButton, makeStyles, Tooltip } from '@material-ui/core'
-import type { SvgIconComponent } from '@material-ui/icons'
+import type { IconButtonProps } from '@material-ui/core';
+import { IconButton, makeStyles, Tooltip } from '@material-ui/core';
+import type { SvgIconComponent } from '@material-ui/icons';
 import {
   Code as CodeIcon,
   GitHub as GitHubIcon,
   LibraryBooks as LibraryBooksIcon,
   LocalOffer as LocalOfferIcon,
   Settings as SettingsIcon,
-} from '@material-ui/icons'
-import { Link } from 'gatsby'
-import React from 'react'
+} from '@material-ui/icons';
+import { Link } from 'gatsby';
+import React from 'react';
 
 const useStyles = makeStyles({
   navBtn: {
     padding: 0,
     margin: 12,
   },
-})
+});
 
 type NavBtnProps = IconButtonProps<typeof Link> &
   IconButtonProps<'a'> & {
@@ -26,12 +26,12 @@ type NavBtnProps = IconButtonProps<typeof Link> &
   }
 
 function isRelativeLink (link: string): boolean {
-  return link.startsWith('.') || link.startsWith('/')
+  return link.startsWith('.') || link.startsWith('/');
 }
 
 const NavBtn: React.FC<NavBtnProps> = (props) => {
-  const classes = useStyles()
-  const { title, to, Icon, ...restProps } = props
+  const classes = useStyles();
+  const { title, to, Icon, ...restProps } = props;
   return (
     <Tooltip title={title} placement="bottom" arrow>
       <IconButton
@@ -45,10 +45,10 @@ const NavBtn: React.FC<NavBtnProps> = (props) => {
         <Icon />
       </IconButton>
     </Tooltip>
-  )
-}
+  );
+};
 
-const OIWikiGithub = 'https://github.com/OI-wiki/OI-wiki'
+const OIWikiGithub = 'https://github.com/OI-wiki/OI-wiki';
 
 const NavBtnGroup: React.FC = () => {
   return (
@@ -65,7 +65,7 @@ const NavBtnGroup: React.FC = () => {
         rel="noreferrer noopener"
       />
     </>
-  )
-}
+  );
+};
 
-export default NavBtnGroup
+export default NavBtnGroup;

--- a/gatsby-theme-oi-wiki/src/components/NavAndDrawer/index.tsx
+++ b/gatsby-theme-oi-wiki/src/components/NavAndDrawer/index.tsx
@@ -1,52 +1,52 @@
-import { AppBar, Button, Drawer, Hidden, IconButton, Toolbar, Typography } from '@material-ui/core'
-import { useTheme } from '@material-ui/core/styles'
-import { Link } from 'gatsby'
-import React from 'react'
-import { Menu as MenuIcon, School as SchoolIcon } from '@material-ui/icons'
-import clsx from 'clsx'
+import { AppBar, Button, Drawer, Hidden, IconButton, Toolbar, Typography } from '@material-ui/core';
+import { useTheme } from '@material-ui/core/styles';
+import { Link } from 'gatsby';
+import React from 'react';
+import { Menu as MenuIcon, School as SchoolIcon } from '@material-ui/icons';
+import clsx from 'clsx';
 
-import trimTrailingSlash from '../../lib/trailingSlash'
-import pathList from '../../sidebar.yaml'
-import SiderContent from '../Sidebar'
-import Tabs from '../Tabs'
-import SmallScreenMenu from '../SmallScreenMenu'
-import { useStyles } from './styles'
-import { flattenObject } from './utils'
-import { useSetting } from '../../lib/useSetting'
-import NavBtnGroup from './NavBtnGroup'
-import Search from '../Search'
-import { StrIndexObj } from '../../types/common'
+import trimTrailingSlash from '../../lib/trailingSlash';
+import pathList from '../../sidebar.yaml';
+import SiderContent from '../Sidebar';
+import Tabs from '../Tabs';
+import SmallScreenMenu from '../SmallScreenMenu';
+import { useStyles } from './styles';
+import { flattenObject } from './utils';
+import { useSetting } from '../../lib/useSetting';
+import NavBtnGroup from './NavBtnGroup';
+import Search from '../Search';
+import { StrIndexObj } from '../../types/common';
 
 const getTabIDFromLocation = (location: string, pathList: StrIndexObj<StrIndexObj>): number => {
-  const locationTrimmed = trimTrailingSlash(location)
+  const locationTrimmed = trimTrailingSlash(location);
   for (const v of Object.entries(pathList)) {
-    if (Object.values(flattenObject(v[1])).map(v => trimTrailingSlash(v as string)).indexOf(locationTrimmed) > -1) return +v[0]
+    if (Object.values(flattenObject(v[1])).map(v => trimTrailingSlash(v as string)).indexOf(locationTrimmed) > -1) return +v[0];
   }
-  return -1
-}
+  return -1;
+};
 
 interface ResponsiveDrawerProps {
   pathname: string
 }
 
 const ResponsiveDrawer: React.FC<ResponsiveDrawerProps> = (props) => {
-  const { pathname } = props
-  const [settings] = useSetting()
-  const theme = useTheme()
+  const { pathname } = props;
+  const [settings] = useSetting();
+  const theme = useTheme();
   const [navColor, textColor] = settings.theme.primary
     ? [settings.theme.primary.main, settings.theme.primary.contrastText]
-    : [theme.palette.background.paper, 'rgba(var(--text-primary))']
+    : [theme.palette.background.paper, 'rgba(var(--text-primary))'];
   const classes = useStyles({
     appBar: {
       background: navColor,
       color: textColor as string,
     },
-  })
-  const [mobileOpen, setMobileOpen] = React.useState(false)
+  });
+  const [mobileOpen, setMobileOpen] = React.useState(false);
   const handleDrawerToggle = (): void => {
-    setMobileOpen(!mobileOpen)
-  }
-  const tabID = getTabIDFromLocation(pathname, pathList)
+    setMobileOpen(!mobileOpen);
+  };
+  const tabID = getTabIDFromLocation(pathname, pathList);
 
   return (
     <>
@@ -106,9 +106,9 @@ const ResponsiveDrawer: React.FC<ResponsiveDrawerProps> = (props) => {
         </Drawer>
       </Hidden>
     </>
-  )
-}
+  );
+};
 
-const NavAndDrawer = React.memo(ResponsiveDrawer, (a, b) => a.pathname === b.pathname)
+const NavAndDrawer = React.memo(ResponsiveDrawer, (a, b) => a.pathname === b.pathname);
 
-export default NavAndDrawer
+export default NavAndDrawer;

--- a/gatsby-theme-oi-wiki/src/components/NavAndDrawer/styles.tsx
+++ b/gatsby-theme-oi-wiki/src/components/NavAndDrawer/styles.tsx
@@ -1,7 +1,7 @@
-import { makeStyles } from '@material-ui/core/styles'
-import { scrollbarStyle } from '../../styles/scrollbar'
+import { makeStyles } from '@material-ui/core/styles';
+import { scrollbarStyle } from '../../styles/scrollbar';
 
-const drawerWidth = 250
+const drawerWidth = 250;
 
 interface Props {
   appBar: {
@@ -53,6 +53,6 @@ const useStyles = makeStyles((theme) => ({
   iconItem: {
     minWidth: theme.spacing(5),
   },
-}))
+}));
 
-export { useStyles }
+export { useStyles };

--- a/gatsby-theme-oi-wiki/src/components/NavAndDrawer/utils.tsx
+++ b/gatsby-theme-oi-wiki/src/components/NavAndDrawer/utils.tsx
@@ -1,26 +1,26 @@
-import { StrIndexObj } from '../../types/common'
+import { StrIndexObj } from '../../types/common';
 
 /**
  * Flatten JS object (keys and values) to a single depth object
  * (ref: https://stackoverflow.com/a/53739792)
  */
 export function flattenObject(ob: StrIndexObj<any>): StrIndexObj {
-  const toReturn: StrIndexObj = {}
+  const toReturn: StrIndexObj = {};
 
   for (const i in ob) {
     if (Object.prototype.hasOwnProperty.call(ob, i)) {
       if ((typeof ob[i]) === 'object' && ob[i] !== null) {
-        const flatObject = flattenObject(ob[i])
+        const flatObject = flattenObject(ob[i]);
 
         for (const x in flatObject) {
           if (Object.prototype.hasOwnProperty.call(flatObject, x)) {
-            toReturn[i + '.' + x] = flatObject[x]
+            toReturn[i + '.' + x] = flatObject[x];
           }
         }
       } else {
-        toReturn[i] = ob[i]
+        toReturn[i] = ob[i];
       }
     }
   }
-  return toReturn
+  return toReturn;
 }

--- a/gatsby-theme-oi-wiki/src/components/Output.tsx
+++ b/gatsby-theme-oi-wiki/src/components/Output.tsx
@@ -7,14 +7,14 @@ import {
   Typography,
   useMediaQuery,
   useTheme,
-} from '@material-ui/core'
-import AccessTime from '@material-ui/icons/AccessTime'
-import Storage from '@material-ui/icons/Storage'
-import React from 'react'
-import type { TransformedResponseData } from '../lib/play/useRunner'
-import Indicator, { IndicatorProps } from './Indicator'
-import useDarkMode from '../lib/useDarkMode'
-import clsx from 'clsx'
+} from '@material-ui/core';
+import AccessTime from '@material-ui/icons/AccessTime';
+import Storage from '@material-ui/icons/Storage';
+import React from 'react';
+import type { TransformedResponseData } from '../lib/play/useRunner';
+import Indicator, { IndicatorProps } from './Indicator';
+import useDarkMode from '../lib/useDarkMode';
+import clsx from 'clsx';
 
 const useStyles = makeStyles((theme) => ({
   root: {
@@ -64,7 +64,7 @@ const useStyles = makeStyles((theme) => ({
     color: theme.palette.info.dark,
     fontWeight: 'bold',
   },
-}))
+}));
 
 const statusSeverityMap: Record<
   TransformedResponseData['status'] | 'No Status Info',
@@ -77,15 +77,15 @@ const statusSeverityMap: Record<
   'Runtime Error': 'error',
   'Execute Failure': 'error',
   'No Status Info': 'info',
-})
+});
 
 const Output = React.forwardRef<
   unknown,
   { output: TransformedResponseData | null }
 >(({ output }, ref) => {
-  const classes = useStyles({ darkMode: useDarkMode() })
-  const theme = useTheme()
-  const matches = useMediaQuery(theme.breakpoints.down('xs'))
+  const classes = useStyles({ darkMode: useDarkMode() });
+  const theme = useTheme();
+  const matches = useMediaQuery(theme.breakpoints.down('xs'));
 
   const {
     time = '?',
@@ -94,7 +94,7 @@ const Output = React.forwardRef<
     ceInfo,
     stdout,
     stderr,
-  } = output || {}
+  } = output || {};
 
   return (
     <Paper ref={ref} className={classes.root}>
@@ -138,7 +138,7 @@ const Output = React.forwardRef<
       <Divider />
       <pre>{stdout === '' ? '似乎没有输出哦...' : stdout}</pre>
     </Paper>
-  )
-})
+  );
+});
 
-export default Output
+export default Output;

--- a/gatsby-theme-oi-wiki/src/components/Search/ResultList.tsx
+++ b/gatsby-theme-oi-wiki/src/components/Search/ResultList.tsx
@@ -1,8 +1,8 @@
-import { List, ListItem, ListItemIcon, ListItemText, Typography } from '@material-ui/core'
-import { Link } from 'gatsby'
-import React from 'react'
-import { FindInPage as FindInPageIcon } from '@material-ui/icons'
-import { useStyles } from './styles'
+import { List, ListItem, ListItemIcon, ListItemText, Typography } from '@material-ui/core';
+import { Link } from 'gatsby';
+import React from 'react';
+import { FindInPage as FindInPageIcon } from '@material-ui/icons';
+import { useStyles } from './styles';
 
 export interface ResultItem {
   url: string;
@@ -18,8 +18,8 @@ export interface SearchResultListProps {
 }
 
 const SearchResultList: React.FC<SearchResultListProps> = props => {
-  const { result, isFirstRun, searchKey, classes } = props
-  const resultCount = result.length
+  const { result, isFirstRun, searchKey, classes } = props;
+  const resultCount = result.length;
   return resultCount === 0
     ? (isFirstRun.current
       ? <></>
@@ -66,7 +66,7 @@ const SearchResultList: React.FC<SearchResultListProps> = props => {
             />
           </ListItem>)}
       </List>
-    </>)
-}
+    </>);
+};
 
-export default SearchResultList
+export default SearchResultList;

--- a/gatsby-theme-oi-wiki/src/components/Search/hooks.ts
+++ b/gatsby-theme-oi-wiki/src/components/Search/hooks.ts
@@ -1,4 +1,4 @@
-import { useEffect, useState } from 'react'
+import { useEffect, useState } from 'react';
 
 export interface WindowDimensions {
   width: number;
@@ -12,16 +12,16 @@ export interface WindowDimensions {
  * @param timeout
  */
 const useDebounce = <T = any>(value: T, timeout: number): T => {
-  const [state, setState] = useState(value)
+  const [state, setState] = useState(value);
 
   useEffect(() => {
-    const handler = setTimeout(() => setState(value), timeout)
+    const handler = setTimeout(() => setState(value), timeout);
 
-    return () => clearTimeout(handler)
-  }, [value, timeout])
+    return () => clearTimeout(handler);
+  }, [value, timeout]);
 
-  return state
-}
+  return state;
+};
 
 /**
  * 在组件挂载后计算屏幕宽度并返回
@@ -30,22 +30,22 @@ const useWindowDimensions = (): WindowDimensions => {
   const [windowDimensions, setWindowDimensions] = useState<WindowDimensions>({
     width: 0,
     height: 0,
-  })
+  });
 
   useEffect(() => {
     const handleResize = (): void => {
       setWindowDimensions({
         width: window.innerWidth,
         height: window.innerHeight,
-      })
-    }
+      });
+    };
 
-    handleResize()
-    window.addEventListener('resize', handleResize)
-    return () => window.removeEventListener('resize', handleResize)
-  }, [])
+    handleResize();
+    window.addEventListener('resize', handleResize);
+    return () => window.removeEventListener('resize', handleResize);
+  }, []);
 
-  return windowDimensions
-}
+  return windowDimensions;
+};
 
-export { useDebounce, useWindowDimensions }
+export { useDebounce, useWindowDimensions };

--- a/gatsby-theme-oi-wiki/src/components/Search/index.tsx
+++ b/gatsby-theme-oi-wiki/src/components/Search/index.tsx
@@ -1,13 +1,13 @@
-import { Backdrop, Dialog, IconButton, InputBase, Paper } from '@material-ui/core'
-import { ArrowBack as ArrowBackIcon, Search as SearchIcon } from '@material-ui/icons'
+import { Backdrop, Dialog, IconButton, InputBase, Paper } from '@material-ui/core';
+import { ArrowBack as ArrowBackIcon, Search as SearchIcon } from '@material-ui/icons';
 
-import clsx from 'clsx'
-import React, { useEffect, useRef, useState } from 'react'
-import useDarkMode from '../../lib/useDarkMode'
+import clsx from 'clsx';
+import React, { useEffect, useRef, useState } from 'react';
+import useDarkMode from '../../lib/useDarkMode';
 
-import { useStyles } from './styles'
-import SearchResultList from './ResultList'
-import { useDebounce, useWindowDimensions } from './hooks'
+import { useStyles } from './styles';
+import SearchResultList from './ResultList';
+import { useDebounce, useWindowDimensions } from './hooks';
 
 /**
  * 从 API 获取搜索数据
@@ -15,19 +15,19 @@ import { useDebounce, useWindowDimensions } from './hooks'
  */
 const fetchResult = (str: string): Promise<any> =>
   fetch(`https://search.oi-wiki.org:8443/?s=${encodeURIComponent(str)}`)
-    .then((response) => response.json())
+    .then((response) => response.json());
 
 const Search: React.FC = () => {
-  const [searchKey, setSearchKey] = useState('')
-  const [result, setResult] = useState([])
-  const [open, setOpen] = useState(false)
-  const debouncedKey = useDebounce(searchKey, 500)
-  const classes = useStyles()
+  const [searchKey, setSearchKey] = useState('');
+  const [result, setResult] = useState([]);
+  const [open, setOpen] = useState(false);
+  const debouncedKey = useDebounce(searchKey, 500);
+  const classes = useStyles();
 
-  const isFirstRun = useRef(true)
+  const isFirstRun = useRef(true);
 
-  const enableDark = useDarkMode()
-  const { width } = useWindowDimensions()
+  const enableDark = useDarkMode();
+  const { width } = useWindowDimensions();
 
   useEffect(() => {
     if (debouncedKey !== '') {
@@ -36,13 +36,13 @@ const Search: React.FC = () => {
         // set result after set isFirstRun
         // so when there's no result on first run
         // the user is prompted with the notice
-        isFirstRun.current = false
-        setResult(val)
-      })
+        isFirstRun.current = false;
+        setResult(val);
+      });
     } else {
-      setResult([])
+      setResult([]);
     }
-  }, [debouncedKey])
+  }, [debouncedKey]);
 
   // 600px is sm
   if (width > 600) {
@@ -60,10 +60,10 @@ const Search: React.FC = () => {
           type="search"
           placeholder="键入以开始搜索"
           onChange={(ev) => {
-            setSearchKey(ev.target.value)
+            setSearchKey(ev.target.value);
           }}
           onFocus={() => {
-            setOpen(true)
+            setOpen(true);
           }}
           classes={{
             root: clsx(classes.inputRoot, searchKey && classes.wideInput),
@@ -86,28 +86,28 @@ const Search: React.FC = () => {
         className={classes.backdrop}
         open={open}
         onClick={() => {
-          setOpen(false)
+          setOpen(false);
         }}
       />
-    </>
+    </>;
   } else {
     return <>
       <IconButton onClick={() => {
-        setOpen(true)
+        setOpen(true);
       }} className={classes.smallScreenSearchIcon}>
         <SearchIcon/>
       </IconButton>
       <Dialog
         open={open}
         onClose={() => {
-          setOpen(false)
+          setOpen(false);
         }}
         fullWidth={true}
         fullScreen
       >
         <Paper component="div" className={classes.dialogHeader}>
           <IconButton className={classes.smallScreenReturnIcon} onClick={() => {
-            setOpen(false)
+            setOpen(false);
           }}>
             <ArrowBackIcon/>
           </IconButton>
@@ -115,7 +115,7 @@ const Search: React.FC = () => {
             type="search"
             placeholder="键入以开始搜索"
             onChange={(ev) => {
-              setSearchKey(ev.target.value)
+              setSearchKey(ev.target.value);
             }}
             classes={{
               root: classes.smallScreenInputRoot,
@@ -134,8 +134,8 @@ const Search: React.FC = () => {
           />
         )}
       </Dialog>
-    </>
+    </>;
   }
-}
+};
 
-export default Search
+export default Search;

--- a/gatsby-theme-oi-wiki/src/components/Search/styles.ts
+++ b/gatsby-theme-oi-wiki/src/components/Search/styles.ts
@@ -1,5 +1,5 @@
-import { alpha, makeStyles } from '@material-ui/core/styles'
-import { scrollbarStyle } from '../../styles/scrollbar'
+import { alpha, makeStyles } from '@material-ui/core/styles';
+import { scrollbarStyle } from '../../styles/scrollbar';
 
 export const useStyles = makeStyles((theme) => ({
   container: {
@@ -140,4 +140,4 @@ export const useStyles = makeStyles((theme) => ({
     '-moz-border-radius': '0',
     'border-radius': '0',
   },
-}))
+}));

--- a/gatsby-theme-oi-wiki/src/components/Seo.tsx
+++ b/gatsby-theme-oi-wiki/src/components/Seo.tsx
@@ -1,9 +1,9 @@
-import React from 'react'
-import { Helmet } from 'react-helmet'
-import { useLocation } from '@reach/router'
-import { graphql, useStaticQuery } from 'gatsby'
-import { Article, WithContext } from 'schema-dts'
-import { DeepRequiredNonNull } from '../types/common'
+import React from 'react';
+import { Helmet } from 'react-helmet';
+import { useLocation } from '@reach/router';
+import { graphql, useStaticQuery } from 'gatsby';
+import { Article, WithContext } from 'schema-dts';
+import { DeepRequiredNonNull } from '../types/common';
 
 interface SEOProps {
   title: string;
@@ -17,7 +17,7 @@ interface SEOProps {
 }
 
 const SEO: React.FC<SEOProps> = (props: SEOProps) => {
-  const { pathname } = useLocation()
+  const { pathname } = useLocation();
   const { site: { siteMetadata } } = useStaticQuery<GatsbyTypes.SEOQuery>(graphql`
     query SEO {
       site {
@@ -29,7 +29,7 @@ const SEO: React.FC<SEOProps> = (props: SEOProps) => {
         }
       }
     }
-  `) as DeepRequiredNonNull<GatsbyTypes.SEOQuery>
+  `) as DeepRequiredNonNull<GatsbyTypes.SEOQuery>;
 
   const {
     title = null,
@@ -39,7 +39,7 @@ const SEO: React.FC<SEOProps> = (props: SEOProps) => {
     tags = null,
     dateModified,
     datePublished,
-  } = props
+  } = props;
 
   const seo = {
     title: title || siteMetadata.defaultTitle,
@@ -48,7 +48,7 @@ const SEO: React.FC<SEOProps> = (props: SEOProps) => {
     url: `${siteMetadata.siteUrl}${pathname}`,
     author: author && author.split(','),
     tags: tags,
-  }
+  };
 
   const schemaMarkUp: WithContext<Article> = {
     '@context': 'https://schema.org',
@@ -70,7 +70,7 @@ const SEO: React.FC<SEOProps> = (props: SEOProps) => {
         url: seo.image,
       },
     },
-  }
+  };
 
   return (
     <Helmet>
@@ -99,7 +99,7 @@ const SEO: React.FC<SEOProps> = (props: SEOProps) => {
       {seo.image && <meta name="twitter:image" content={seo.image}/>}
       {schemaMarkUp && <script type="application/ld+json">{JSON.stringify(schemaMarkUp, null, 2)}</script>}
     </Helmet>
-  )
-}
+  );
+};
 
-export default SEO
+export default SEO;

--- a/gatsby-theme-oi-wiki/src/components/Sidebar.tsx
+++ b/gatsby-theme-oi-wiki/src/components/Sidebar.tsx
@@ -1,11 +1,11 @@
-import { Collapse, List, ListItem, ListItemText, Typography } from '@material-ui/core'
+import { Collapse, List, ListItem, ListItemText, Typography } from '@material-ui/core';
 
-import { makeStyles } from '@material-ui/core/styles'
-import React, { useState } from 'react'
-import ExpandLessIcon from '@material-ui/icons/ExpandLess'
-import ExpandMoreIcon from '@material-ui/icons/ExpandMore'
-import { Link } from 'gatsby'
-import trimTrailingSlash from '../lib/trailingSlash'
+import { makeStyles } from '@material-ui/core/styles';
+import React, { useState } from 'react';
+import ExpandLessIcon from '@material-ui/icons/ExpandLess';
+import ExpandMoreIcon from '@material-ui/icons/ExpandMore';
+import { Link } from 'gatsby';
+import trimTrailingSlash from '../lib/trailingSlash';
 
 const useStyles = makeStyles((theme) => ({
   listItem: {
@@ -26,7 +26,7 @@ const useStyles = makeStyles((theme) => ({
     width: '100%',
     height: '100%',
   },
-}))
+}));
 
 enum NodeType {
   Leaf, NonLeaf
@@ -67,9 +67,9 @@ export interface SidebarProps {
 }
 
 const NonLeafItem: React.FC<NonLeafItemProps> = (props) => {
-  const classes = useStyles()
-  const { name, padding, childItems, isOpen } = props
-  const [open, setOpen] = useState(isOpen)
+  const classes = useStyles();
+  const { name, padding, childItems, isOpen } = props;
+  const [open, setOpen] = useState(isOpen);
 
   return <div>
     <ListItem
@@ -90,12 +90,12 @@ const NonLeafItem: React.FC<NonLeafItemProps> = (props) => {
     <Collapse in={open} timeout="auto" unmountOnExit>
       <List disablePadding>{childItems}</List>
     </Collapse>
-  </div>
-}
+  </div>;
+};
 
 const LeafItem: React.FC<LeafItemProps> = (props) => {
-  const classes = useStyles()
-  const { name, path, padding, selected } = props
+  const classes = useStyles();
+  const { name, path, padding, selected } = props;
 
   return <Link key={name} to={path}>
     <ListItem
@@ -112,60 +112,60 @@ const LeafItem: React.FC<LeafItemProps> = (props) => {
         }
       />
     </ListItem>
-  </Link>
-}
+  </Link>;
+};
 
 function Item(node: PathListNode, padding: number, pathname: string): [React.ReactElement, boolean] {
   if (node.type === NodeType.Leaf) {
-    const selected = trimTrailingSlash(node.path) === trimTrailingSlash(pathname)
+    const selected = trimTrailingSlash(node.path) === trimTrailingSlash(pathname);
     return [
       <LeafItem key={node.path} padding={padding} selected={selected} {...node}/>,
       selected,
-    ]
+    ];
   } else {
-    const children = node.children
-    let isOpen = false
-    const items: NonLeafItemProps['childItems'] = []
+    const children = node.children;
+    let isOpen = false;
+    const items: NonLeafItemProps['childItems'] = [];
 
     children.forEach((v) => {
-      const [item, selected] = Item(v, padding + 16, pathname)
-      if (selected) isOpen = selected
-      items.push(item)
-    })
+      const [item, selected] = Item(v, padding + 16, pathname);
+      if (selected) isOpen = selected;
+      items.push(item);
+    });
 
     return [
       <NonLeafItem key={node.name} isOpen={isOpen} childItems={items} padding={padding} {...node} />,
       isOpen,
-    ]
+    ];
   }
 }
 
 function getTypedPathList(pathList: PathListType): TypedPathList {
-  const resArray: TypedPathList = []
+  const resArray: TypedPathList = [];
   for (const i of pathList) {
-    const [[name, a]] = Object.entries(i)
+    const [[name, a]] = Object.entries(i);
     if (typeof a === 'string') {
-      resArray.push({ name, path: a, type: NodeType.Leaf })
+      resArray.push({ name, path: a, type: NodeType.Leaf });
     } else {
-      resArray.push({ name, children: getTypedPathList(a), type: NodeType.NonLeaf })
+      resArray.push({ name, children: getTypedPathList(a), type: NodeType.NonLeaf });
     }
   }
-  return resArray
+  return resArray;
 }
 
 const Sidebar: React.FC<SidebarProps> = (props) => {
-  const classes = useStyles()
-  const pathList = props.pathList
-  const typedPathList = getTypedPathList(pathList)
+  const classes = useStyles();
+  const pathList = props.pathList;
+  const typedPathList = getTypedPathList(pathList);
   const res = typedPathList
     .map((item) => Item(item, 16, props.pathname))
-    .map(([x]) => x)
+    .map(([x]) => x);
   return (
     <List className={classes.list}>
       {res}
     </List>
-  )
-}
+  );
+};
 
 // 只比较 pathname，而不比较 pathList，考虑到当 pathList 不同时，pathname 也一定不同，因此这样比较可以节省计算量
-export default React.memo(Sidebar, (prev, next) => prev.pathname === next.pathname)
+export default React.memo(Sidebar, (prev, next) => prev.pathname === next.pathname);

--- a/gatsby-theme-oi-wiki/src/components/SmallScreenMenu.tsx
+++ b/gatsby-theme-oi-wiki/src/components/SmallScreenMenu.tsx
@@ -1,15 +1,15 @@
-import { makeStyles } from '@material-ui/core/styles'
+import { makeStyles } from '@material-ui/core/styles';
 
-import { Hidden, IconButton, ListItemIcon, Menu, MenuItem } from '@material-ui/core'
+import { Hidden, IconButton, ListItemIcon, Menu, MenuItem } from '@material-ui/core';
 
-import SettingsIcon from '@material-ui/icons/Settings'
-import LibraryBooksIcon from '@material-ui/icons/LibraryBooks'
-import LocalOfferIcon from '@material-ui/icons/LocalOffer'
-import GitHubIcon from '@material-ui/icons/GitHub'
-import MoreVertIcon from '@material-ui/icons/MoreVert'
-import CodeIcon from '@material-ui/icons/Code'
+import SettingsIcon from '@material-ui/icons/Settings';
+import LibraryBooksIcon from '@material-ui/icons/LibraryBooks';
+import LocalOfferIcon from '@material-ui/icons/LocalOffer';
+import GitHubIcon from '@material-ui/icons/GitHub';
+import MoreVertIcon from '@material-ui/icons/MoreVert';
+import CodeIcon from '@material-ui/icons/Code';
 
-import React from 'react'
+import React from 'react';
 
 const useStyles = makeStyles((theme) => ({
   iconItem: {
@@ -18,20 +18,20 @@ const useStyles = makeStyles((theme) => ({
   sideMenu: {
     transition: 'none !important',
   },
-}))
+}));
 
 const SmallScreenMenu: React.FC = () => {
-  const classes = useStyles()
-  const [anchorEl, setAnchorEl] = React.useState(null)
-  const OIWikiGithub = 'https://github.com/OI-wiki/OI-wiki'
+  const classes = useStyles();
+  const [anchorEl, setAnchorEl] = React.useState(null);
+  const OIWikiGithub = 'https://github.com/OI-wiki/OI-wiki';
 
   const handleClick = React.useCallback((event): void => {
-    setAnchorEl(event.currentTarget)
-  }, [])
+    setAnchorEl(event.currentTarget);
+  }, []);
 
   const handleClose = React.useCallback((): void => {
-    setAnchorEl(null)
-  }, [])
+    setAnchorEl(null);
+  }, []);
 
   return (
     <Hidden mdUp implementation="js">
@@ -82,7 +82,7 @@ const SmallScreenMenu: React.FC = () => {
         </MenuItem>
       </Menu>
     </Hidden>
-  )
-}
+  );
+};
 
-export default SmallScreenMenu
+export default SmallScreenMenu;

--- a/gatsby-theme-oi-wiki/src/components/StyledLayout.tsx
+++ b/gatsby-theme-oi-wiki/src/components/StyledLayout.tsx
@@ -1,11 +1,11 @@
-import { CssBaseline, Divider, Grid, Typography } from '@material-ui/core'
+import { CssBaseline, Divider, Grid, Typography } from '@material-ui/core';
 
-import { makeStyles, ThemeProvider, useTheme } from '@material-ui/core/styles'
-import Alert from '@material-ui/lab/Alert'
-import FormatPaintIcon from '@material-ui/icons/FormatPaint'
-import React from 'react'
-import { Helmet } from 'react-helmet'
-import { graphql, useStaticQuery } from 'gatsby'
+import { makeStyles, ThemeProvider, useTheme } from '@material-ui/core/styles';
+import Alert from '@material-ui/lab/Alert';
+import FormatPaintIcon from '@material-ui/icons/FormatPaint';
+import React from 'react';
+import { Helmet } from 'react-helmet';
+import { graphql, useStaticQuery } from 'gatsby';
 import {
   adaptiveTheme,
   AutoCssBaseline,
@@ -13,16 +13,16 @@ import {
   DarkCssBaseline,
   LightCssBaseline,
   SecondaryColorCssBaseline,
-} from '../theme'
-import { scrollbarStyle } from '../styles/scrollbar'
-import Comment from './Comment'
-import Toc, { TocObj } from './Toc'
-import BackTop from './BackTop'
-import Footer from './Footer'
-import Meta, { MetaProps } from './Meta'
-import Title from './Title'
-import NavAndDrawer from './NavAndDrawer'
-import { RequiredNonNull } from '../types/common'
+} from '../theme';
+import { scrollbarStyle } from '../styles/scrollbar';
+import Comment from './Comment';
+import Toc, { TocObj } from './Toc';
+import BackTop from './BackTop';
+import Footer from './Footer';
+import Meta, { MetaProps } from './Meta';
+import Title from './Title';
+import NavAndDrawer from './NavAndDrawer';
+import { RequiredNonNull } from '../types/common';
 
 const useStyles = makeStyles((theme) => ({
   toolbar: {
@@ -67,7 +67,7 @@ const useStyles = makeStyles((theme) => ({
   wip: {
     margin: `${theme.spacing(2)}px 0px`,
   },
-}))
+}));
 
 interface MyLayoutProps extends Partial<MetaProps> {
   description?: string;
@@ -81,8 +81,8 @@ interface MyLayoutProps extends Partial<MetaProps> {
 }
 
 const MyLayout: React.FC<MyLayoutProps> = (props) => {
-  const theme = useTheme()
-  const classes = useStyles()
+  const theme = useTheme();
+  const classes = useStyles();
   const data = useStaticQuery<GatsbyTypes.SiteDescQuery>(graphql`
     query SiteDesc {
       site {
@@ -91,12 +91,12 @@ const MyLayout: React.FC<MyLayoutProps> = (props) => {
           title
         }
       }
-    }`)
+    }`);
 
   const {
     description: siteDesc,
     title: siteTitle,
-  } = data?.site?.siteMetadata as RequiredNonNull<GatsbyTypes.SiteSiteMetadata>
+  } = data?.site?.siteMetadata as RequiredNonNull<GatsbyTypes.SiteSiteMetadata>;
 
   const {
     title = '',
@@ -114,18 +114,18 @@ const MyLayout: React.FC<MyLayoutProps> = (props) => {
     isWIP = false,
     location = window.location,
     children,
-  } = props
-  const titleMetaProps = { title, location, relativePath }
-  const metaProps = { tags, modifiedTime, authors }
+  } = props;
+  const titleMetaProps = { title, location, relativePath };
+  const metaProps = { tags, modifiedTime, authors };
 
-  const gridWidthMdUp = overflow ? 12 : 10
-  const desc = description || siteDesc
+  const gridWidthMdUp = overflow ? 12 : 10;
+  const desc = description || siteDesc;
 
   const WIPAlert = (
     <Alert severity="info" icon={<FormatPaintIcon/>} className={classes.wip}>
       本文内容尚不完善，我们正在努力施工中。您可以保存此页链接稍后再看，或者帮助我们修订此页面！
     </Alert>
-  )
+  );
   return (
     <>
       <Helmet>
@@ -173,8 +173,8 @@ const MyLayout: React.FC<MyLayoutProps> = (props) => {
       </Grid>}
       <BackTop/>
     </>
-  )
-}
+  );
+};
 
 const StyledLayout: React.FC<MyLayoutProps> = (props) =>
   <ThemeProvider theme={adaptiveTheme}>
@@ -185,6 +185,6 @@ const StyledLayout: React.FC<MyLayoutProps> = (props) =>
     <SecondaryColorCssBaseline/>
     <AutoCssBaseline/>
     <MyLayout {...props} />
-  </ThemeProvider>
+  </ThemeProvider>;
 
-export default StyledLayout
+export default StyledLayout;

--- a/gatsby-theme-oi-wiki/src/components/Summary.tsx
+++ b/gatsby-theme-oi-wiki/src/components/Summary.tsx
@@ -1,9 +1,9 @@
-import { AccordionSummary, AccordionSummaryProps } from '@material-ui/core'
-import blue from '@material-ui/core/colors/blue'
-import { makeStyles } from '@material-ui/core/styles'
-import EditIcon from '@material-ui/icons/Edit'
-import ExpandMoreIcon from '@material-ui/icons/ExpandMore'
-import React from 'react'
+import { AccordionSummary, AccordionSummaryProps } from '@material-ui/core';
+import blue from '@material-ui/core/colors/blue';
+import { makeStyles } from '@material-ui/core/styles';
+import EditIcon from '@material-ui/icons/Edit';
+import ExpandMoreIcon from '@material-ui/icons/ExpandMore';
+import React from 'react';
 
 const useStyles = makeStyles((theme) => ({
   expanded: {}, // DONT DELETE THIS
@@ -32,15 +32,15 @@ const useStyles = makeStyles((theme) => ({
     },
     fontWeight: 'bold',
   },
-}))
+}));
 
 export interface SummaryProps extends AccordionSummaryProps {
   className: string;
 }
 
 const Summary: React.FC<SummaryProps> = (props) => {
-  const { children, ...others } = props
-  const classes = useStyles()
+  const { children, ...others } = props;
+  const classes = useStyles();
 
   return (
     <AccordionSummary
@@ -58,7 +58,7 @@ const Summary: React.FC<SummaryProps> = (props) => {
       />
       {children}
     </AccordionSummary>
-  )
-}
+  );
+};
 
-export default Summary
+export default Summary;

--- a/gatsby-theme-oi-wiki/src/components/Tabs.tsx
+++ b/gatsby-theme-oi-wiki/src/components/Tabs.tsx
@@ -1,7 +1,7 @@
-import { makeStyles } from '@material-ui/core/styles'
-import Tab from '@material-ui/core/Tab'
-import Tabs from '@material-ui/core/Tabs'
-import React from 'react'
+import { makeStyles } from '@material-ui/core/styles';
+import Tab from '@material-ui/core/Tab';
+import Tabs from '@material-ui/core/Tabs';
+import React from 'react';
 
 const useStyles = makeStyles((theme) => ({
   tab: {
@@ -13,13 +13,13 @@ const useStyles = makeStyles((theme) => ({
       opacity: '1',
     },
   },
-}))
+}));
 
 const useIndicatorStyles = makeStyles(() => ({
   indicator: {
     height: '3px',
   },
-}))
+}));
 
 interface NavTabsProps {
   tabID: number;
@@ -27,14 +27,14 @@ interface NavTabsProps {
 }
 
 const NavTabs: React.FC<NavTabsProps> = (props) => {
-  const classes = useStyles()
-  const indicatorClasses = useIndicatorStyles()
-  const { tabID, pathList } = props
-  const newTabs = []
+  const classes = useStyles();
+  const indicatorClasses = useIndicatorStyles();
+  const { tabID, pathList } = props;
+  const newTabs = [];
 
   for (const curTab of pathList.values()) {
-    const curTitle = Object.keys(curTab)[0]
-    const values = Object.values(curTab)[0]
+    const curTitle = Object.keys(curTab)[0];
+    const values = Object.values(curTab)[0];
     const curLocation = (typeof values === 'string')
       /*
         - 测试: /test/
@@ -44,16 +44,16 @@ const NavTabs: React.FC<NavTabsProps> = (props) => {
         - 测试:
           - 测试: /test/
       */
-      : Object.values(values[0])[0]
-    newTabs.push({ title: curTitle, link: curLocation })
+      : Object.values(values[0])[0];
+    newTabs.push({ title: curTitle, link: curLocation });
   }
-  const [value, setValue] = React.useState(tabID)
+  const [value, setValue] = React.useState(tabID);
 
   return (
     <Tabs value={value}
           classes={indicatorClasses}
           onChange={(_, newValue) => {
-            setValue(newValue)
+            setValue(newValue);
           }}>
       {newTabs.map(({ title, link }) => (
         <Tab
@@ -66,7 +66,7 @@ const NavTabs: React.FC<NavTabsProps> = (props) => {
         />
       ))}
     </Tabs>
-  )
-}
+  );
+};
 
-export default React.memo(NavTabs, (prev, next) => prev.tabID === next.tabID)
+export default React.memo(NavTabs, (prev, next) => prev.tabID === next.tabID);

--- a/gatsby-theme-oi-wiki/src/components/Tags.tsx
+++ b/gatsby-theme-oi-wiki/src/components/Tags.tsx
@@ -1,21 +1,21 @@
-import Chip from '@material-ui/core/Chip'
-import { makeStyles } from '@material-ui/core/styles'
-import kebabCase from 'lodash/kebabCase'
-import React from 'react'
+import Chip from '@material-ui/core/Chip';
+import { makeStyles } from '@material-ui/core/styles';
+import kebabCase from 'lodash/kebabCase';
+import React from 'react';
 
 const useStyles = makeStyles((theme) => ({
   chip: {
     margin: theme.spacing(0.5),
   },
-}))
+}));
 
 interface Props{
   tags: Array<string>
 }
 
 const Tags: React.FC<Props> = (props: Props) => {
-  const arr = props.tags
-  const classes = useStyles()
+  const arr = props.tags;
+  const classes = useStyles();
   return (
     <div>
       {arr &&
@@ -31,7 +31,7 @@ const Tags: React.FC<Props> = (props: Props) => {
           />
         ))}
     </div>
-  )
-}
+  );
+};
 
-export default Tags
+export default Tags;

--- a/gatsby-theme-oi-wiki/src/components/Time.tsx
+++ b/gatsby-theme-oi-wiki/src/components/Time.tsx
@@ -1,40 +1,40 @@
-import React, { useEffect, useState } from 'react'
-import timeDifference from '../lib/relativeTime'
+import React, { useEffect, useState } from 'react';
+import timeDifference from '../lib/relativeTime';
 
 const defaultProps = {
   defaultShowRelative: true,
   updateInterval: 30 * 1000,
-}
+};
 
 export interface TimeProps extends Partial<typeof defaultProps> {
   time: number | Date | string
 }
 
 const Time: React.FC<TimeProps> = (props) => {
-  const { time, defaultShowRelative, updateInterval } = { ...defaultProps, ...props }
-  const [relativeMode, setRelativeMode] = useState(defaultShowRelative)
-  const [now, setNow] = useState(Date.now())
-  const timestamp = +new Date(time)
+  const { time, defaultShowRelative, updateInterval } = { ...defaultProps, ...props };
+  const [relativeMode, setRelativeMode] = useState(defaultShowRelative);
+  const [now, setNow] = useState(Date.now());
+  const timestamp = +new Date(time);
 
   const toggle = (): void => {
-    setRelativeMode(!relativeMode)
-  }
+    setRelativeMode(!relativeMode);
+  };
 
   useEffect(() => {
     const t = setInterval(() => {
-      setNow(Date.now())
-    }, updateInterval)
+      setNow(Date.now());
+    }, updateInterval);
 
     return () => {
-      clearInterval(t)
-    }
-  }, [updateInterval])
+      clearInterval(t);
+    };
+  }, [updateInterval]);
 
   return <span
     style={{ cursor: 'pointer' }}
     onClick={toggle}>
     {relativeMode ? timeDifference(now, timestamp) : new Date(timestamp).toLocaleString()}
-  </span>
-}
+  </span>;
+};
 
-export default Time
+export default Time;

--- a/gatsby-theme-oi-wiki/src/components/Title.tsx
+++ b/gatsby-theme-oi-wiki/src/components/Title.tsx
@@ -1,7 +1,7 @@
-import React, { useState } from 'react'
-import { createStyles, Grid, Hidden, IconButton, makeStyles, Tooltip, Typography } from '@material-ui/core'
-import EditIcon from '@material-ui/icons/Edit'
-import EditWarn from './EditWarn'
+import React, { useState } from 'react';
+import { createStyles, Grid, Hidden, IconButton, makeStyles, Tooltip, Typography } from '@material-ui/core';
+import EditIcon from '@material-ui/icons/Edit';
+import EditWarn from './EditWarn';
 
 export interface TitleProps {
   title: string,
@@ -26,12 +26,12 @@ const useStyles = makeStyles((theme) => createStyles({
     color: theme.palette.subTitle,
     lineHeight: 1.8,
   },
-}))
+}));
 
 const Title: React.FC<TitleProps> = (props) => {
-  const classes = useStyles()
-  const [dialogOpen, setDialogOpen] = useState(false)
-  const { relativePath, location, title, noEdit } = props
+  const classes = useStyles();
+  const [dialogOpen, setDialogOpen] = useState(false);
+  const { relativePath, location, title, noEdit } = props;
 
   return (
     <>
@@ -63,7 +63,7 @@ const Title: React.FC<TitleProps> = (props) => {
         </Grid>
       </Grid>
     </>
-  )
-}
+  );
+};
 
-export default Title
+export default Title;

--- a/gatsby-theme-oi-wiki/src/components/Toc/Toc.tsx
+++ b/gatsby-theme-oi-wiki/src/components/Toc/Toc.tsx
@@ -1,8 +1,8 @@
-import { Link as MuiLink } from '@material-ui/core'
-import clsx from 'clsx'
-import React from 'react'
-import { makeStyles } from '@material-ui/core/styles'
-import { Nullable, OnClickHandler } from '../../types/common'
+import { Link as MuiLink } from '@material-ui/core';
+import clsx from 'clsx';
+import React from 'react';
+import { makeStyles } from '@material-ui/core/styles';
+import { Nullable, OnClickHandler } from '../../types/common';
 
 export interface Node {
   url: string;
@@ -46,11 +46,11 @@ const useStyles = makeStyles((theme) => ({
   active: {
     borderLeft: `4px solid ${theme.palette.secondary.main}`,
   },
-}))
+}));
 
 const TocItem: React.FC<Props> = (props) => {
-  const { data, onClick, ...restProps } = props
-  const classes = useStyles()
+  const { data, onClick, ...restProps } = props;
+  const classes = useStyles();
   return (
     <MuiLink
       {...restProps}
@@ -59,7 +59,7 @@ const TocItem: React.FC<Props> = (props) => {
       href={data.url}
       underline="none"
       onClick={(e) => {
-        onClick && onClick(data)(e)
+        onClick && onClick(data)(e);
       }}
       style={{
         paddingLeft: `${data.level + 1}em`,
@@ -68,12 +68,12 @@ const TocItem: React.FC<Props> = (props) => {
     >
       <span dangerouslySetInnerHTML={{ __html: data.title }}/>
     </MuiLink>
-  )
-}
+  );
+};
 
 const TocComponent: React.FC<Props> = (props) => {
-  const { data, onClick, ...restProps } = props
-  const classes = useStyles()
+  const { data, onClick, ...restProps } = props;
+  const classes = useStyles();
   return (
     <li id={`toc-${data.url}`} className={clsx(classes.li)}>
       <TocItem data={data} onClick={onClick} {...restProps} />
@@ -82,17 +82,17 @@ const TocComponent: React.FC<Props> = (props) => {
         data.children.map(i => <TocComponent data={i} onClick={onClick} {...restProps} key={i.url}/>)
       }</ul>}
     </li>
-  )
-}
+  );
+};
 
 const TocList: React.FC<TocListProps> = (props) => {
-  const { data, onClick, ...restProps } = props
-  const classes = useStyles()
+  const { data, onClick, ...restProps } = props;
+  const classes = useStyles();
   return (
     <ul className={classes.ul}>{
       data.map(i => <TocComponent data={i} onClick={onClick} {...restProps} key={i.url}/>)
     }</ul>
-  )
-}
+  );
+};
 
-export default TocList
+export default TocList;

--- a/gatsby-theme-oi-wiki/src/components/Toc/index.tsx
+++ b/gatsby-theme-oi-wiki/src/components/Toc/index.tsx
@@ -1,13 +1,13 @@
-import { Typography } from '@material-ui/core'
-import React, { useCallback, useEffect, useRef, useState } from 'react'
-import Slug from 'github-slugger'
+import { Typography } from '@material-ui/core';
+import React, { useCallback, useEffect, useRef, useState } from 'react';
+import Slug from 'github-slugger';
 
-import { useStyles } from './styles'
-import { useSetting } from '../../lib/useSetting'
-import TocList, { Node, TocListProps } from './Toc'
-import { Nullable } from '../../types/common'
-import smoothScrollTo from '../../lib/smoothScroll'
-import useThrottledOnScroll from '../../lib/useThrottledOnScroll'
+import { useStyles } from './styles';
+import { useSetting } from '../../lib/useSetting';
+import TocList, { Node, TocListProps } from './Toc';
+import { Nullable } from '../../types/common';
+import smoothScrollTo from '../../lib/smoothScroll';
+import useThrottledOnScroll from '../../lib/useThrottledOnScroll';
 
 export interface TocItem {
   value: string;
@@ -18,22 +18,22 @@ export interface TocProps {
   toc: TocItem[];
 }
 
-const getIDFromHash = (url: string): string => url.substring(1, url.length)
+const getIDFromHash = (url: string): string => url.substring(1, url.length);
 
 const TocConverter = (items: TocItem[]): Node[] => {
-  const minLevel = items.reduce((v, i) => Math.min(v, i.depth), 5)
-  const curNode: Nullable<Node>[] = Array.from({ length: 6 }, () => null)
-  const data: Node[] = []
-  const REF_EXPR = /ref\d+$/
-  let index: number
+  const minLevel = items.reduce((v, i) => Math.min(v, i.depth), 5);
+  const curNode: Nullable<Node>[] = Array.from({ length: 6 }, () => null);
+  const data: Node[] = [];
+  const REF_EXPR = /ref\d+$/;
+  let index: number;
 
-  const slugs = new Slug()
-  slugs.reset()
+  const slugs = new Slug();
+  slugs.reset();
 
   items.forEach((item) => {
-    const level = item.depth - minLevel
-    const title = item.value.replace(/<[^>]*>?/gm, '')
-    index = level > 0 ? (curNode[level - 1]?.children.length || 0) : data.length
+    const level = item.depth - minLevel;
+    const title = item.value.replace(/<[^>]*>?/gm, '');
+    index = level > 0 ? (curNode[level - 1]?.children.length || 0) : data.length;
     const newNode: Node = {
       url: `#${slugs.slug(title)}`.replace(REF_EXPR, ''),
       title: title.replace(REF_EXPR, ''),
@@ -44,156 +44,156 @@ const TocConverter = (items: TocItem[]): Node[] => {
       element: null,
       parent: null,
       selfElement: null,
-    }
-    curNode[level] = newNode
+    };
+    curNode[level] = newNode;
 
     if (level === 0) {
-      data.push(newNode)
+      data.push(newNode);
     } else {
-      if (curNode[level - 1]) curNode[level - 1]?.children.push(newNode)
-      newNode.parent = curNode[level - 1]
+      if (curNode[level - 1]) curNode[level - 1]?.children.push(newNode);
+      newNode.parent = curNode[level - 1];
     }
-  })
-  return data
-}
+  });
+  return data;
+};
 
 const bindHTMLElement = (toc: Node[]): void => {
   toc.forEach((i, idx, arr) => {
-    if (i.element === null) arr[idx].element = document.getElementById(getIDFromHash(i.url))
-    if (i.selfElement === null) arr[idx].selfElement = document.getElementById(`toc-${i.url}`)
-    if (i.children) bindHTMLElement(i.children)
-  })
-}
+    if (i.element === null) arr[idx].element = document.getElementById(getIDFromHash(i.url));
+    if (i.selfElement === null) arr[idx].selfElement = document.getElementById(`toc-${i.url}`);
+    if (i.children) bindHTMLElement(i.children);
+  });
+};
 
 const TocEl: React.FC<TocProps> = (props) => {
-  const { toc } = props
-  const items = toc
-  const classes = useStyles()
-  const [settings] = useSetting()
+  const { toc } = props;
+  const items = toc;
+  const classes = useStyles();
+  const [settings] = useSetting();
 
-  const newItems = useRef(TocConverter(items))
-  const clickedRef = useRef(false)
-  const unsetClickedRef = useRef<ReturnType<typeof setTimeout>>()
-  const [activeState, setActiveState] = useState<Nullable<Node>>(null)
-  const lstScrollTopRef = useRef(0)
-  const navRef = useRef<HTMLElement>(null)
-  const behavior = settings.animation.smoothScroll ? 'smooth' : 'auto'
+  const newItems = useRef(TocConverter(items));
+  const clickedRef = useRef(false);
+  const unsetClickedRef = useRef<ReturnType<typeof setTimeout>>();
+  const [activeState, setActiveState] = useState<Nullable<Node>>(null);
+  const lstScrollTopRef = useRef(0);
+  const navRef = useRef<HTMLElement>(null);
+  const behavior = settings.animation.smoothScroll ? 'smooth' : 'auto';
 
   useEffect(() => {
-    bindHTMLElement(newItems.current)
-  }, [items])
+    bindHTMLElement(newItems.current);
+  }, [items]);
 
   const nodeSetActive = (node: Nullable<Node>, val: boolean): void => {
-    for (let u = node; u !== null; u = u.parent) u.status = val ? 'expanded' : 'collapse'
-    if (val && node) node.status = 'active'
-  }
+    for (let u = node; u !== null; u = u.parent) u.status = val ? 'expanded' : 'collapse';
+    if (val && node) node.status = 'active';
+  };
 
   const updateActive = useCallback((state: Nullable<Node>): void => {
-    if (activeState?.url === state?.url) return
+    if (activeState?.url === state?.url) return;
 
-    nodeSetActive(activeState, false)
-    nodeSetActive(state, true)
-    setActiveState(state)
-  }, [activeState])
+    nodeSetActive(activeState, false);
+    nodeSetActive(state, true);
+    setActiveState(state);
+  }, [activeState]);
 
   const getNextItem = useCallback((node: Node): Nullable<Node> => {
-    const parent = node.parent
-    const nextIdx = node.index + 1
-    if (parent === null) return newItems.current.length > nextIdx ? newItems.current[nextIdx] : null
-    else return parent.children.length > nextIdx ? parent.children[nextIdx] : getNextItem(parent)
-  }, [])
+    const parent = node.parent;
+    const nextIdx = node.index + 1;
+    if (parent === null) return newItems.current.length > nextIdx ? newItems.current[nextIdx] : null;
+    else return parent.children.length > nextIdx ? parent.children[nextIdx] : getNextItem(parent);
+  }, []);
 
   const getLstChild = useCallback((node: Nullable<Node>): Nullable<Node> =>
-    (node && node.children.length > 0) ? getLstChild(node.children[node.children.length - 1]) : node, [])
+    (node && node.children.length > 0) ? getLstChild(node.children[node.children.length - 1]) : node, []);
 
   const getPrevItem = useCallback((node: Node): Nullable<Node> => {
-    const parent = node.parent
-    const prevIdx = node.index - 1
+    const parent = node.parent;
+    const prevIdx = node.index - 1;
     return prevIdx >= 0
       ? getLstChild((parent === null ? newItems.current : parent.children)[prevIdx])
-      : parent
-  }, [getLstChild])
+      : parent;
+  }, [getLstChild]);
 
   const activeTocOnScroll = useCallback((): void => {
-    if (clickedRef.current) return
+    if (clickedRef.current) return;
 
-    const TO_TOP_DIS = 20
-    const pageScrollTop = window?.pageYOffset || document.documentElement.scrollTop
-    let node: Nullable<Node> = activeState || newItems.current[0]
+    const TO_TOP_DIS = 20;
+    const pageScrollTop = window?.pageYOffset || document.documentElement.scrollTop;
+    let node: Nullable<Node> = activeState || newItems.current[0];
 
     // down dir
     if (pageScrollTop > lstScrollTopRef.current) {
-      let minDisNode = node
+      let minDisNode = node;
       while (node) {
         if (node.element && (node.element.getBoundingClientRect().top > TO_TOP_DIS + 20)) {
-          break
+          break;
         } else {
-          if (node !== minDisNode) minDisNode = node
-          node = node.children.length > 0 ? node.children[0] : getNextItem(node)
+          if (node !== minDisNode) minDisNode = node;
+          node = node.children.length > 0 ? node.children[0] : getNextItem(node);
         }
       }
-      node = minDisNode
+      node = minDisNode;
     } else {
       while (node) {
         // node may have no ele which caused by error id
         if (!node.element || node.element.getBoundingClientRect().top <= TO_TOP_DIS) {
-          break
+          break;
         } else {
-          node = getPrevItem(node)
+          node = getPrevItem(node);
         }
       }
     }
 
     if (activeState !== node) {
-      updateActive(node)
+      updateActive(node);
 
       // scroll the toc
-      if (node?.selfElement) node.selfElement.scrollIntoView({ behavior })
-      else navRef.current?.scrollTo({ top: 0, behavior })
+      if (node?.selfElement) node.selfElement.scrollIntoView({ behavior });
+      else navRef.current?.scrollTo({ top: 0, behavior });
 
       //  change hash
-      window.history.replaceState(null, '', node?.url)
+      window.history.replaceState(null, '', node?.url);
     }
 
-    lstScrollTopRef.current = pageScrollTop
-  }, [activeState, behavior, getNextItem, getPrevItem, updateActive])
+    lstScrollTopRef.current = pageScrollTop;
+  }, [activeState, behavior, getNextItem, getPrevItem, updateActive]);
 
-  useThrottledOnScroll(activeTocOnScroll, 100)
+  useThrottledOnScroll(activeTocOnScroll, 100);
 
   const handleClick: TocListProps['onClick'] = (item) => (event) => {
-    event.preventDefault()
+    event.preventDefault();
 
-    const hash = item.url
-    const yDis = (item.element?.getBoundingClientRect().top || 0) + window?.pageYOffset
+    const hash = item.url;
+    const yDis = (item.element?.getBoundingClientRect().top || 0) + window?.pageYOffset;
 
     if (settings.animation.smoothScroll) {
-      smoothScrollTo(yDis)
+      smoothScrollTo(yDis);
     } else {
-      window?.scrollTo(0, yDis)
+      window?.scrollTo(0, yDis);
     }
 
-    window?.history.pushState(null, '', hash)
-    clickedRef.current = true
+    window?.history.pushState(null, '', hash);
+    clickedRef.current = true;
 
     // clear last unfinished timeout
-    if (unsetClickedRef.current) clearTimeout(unsetClickedRef.current)
+    if (unsetClickedRef.current) clearTimeout(unsetClickedRef.current);
     unsetClickedRef.current = setTimeout(() => {
-      clickedRef.current = false
-    }, 100)
+      clickedRef.current = false;
+    }, 100);
 
     if (activeState?.url !== hash) {
-      updateActive(item)
+      updateActive(item);
     }
-  }
+  };
 
   useEffect(
     () => {
       return () => {
-        clearTimeout(unsetClickedRef.current as never as number)
-      }
+        clearTimeout(unsetClickedRef.current as never as number);
+      };
     },
     [],
-  )
+  );
 
   return (
     <nav ref={navRef} className={classes.main} aria-label="pageTOC">
@@ -206,9 +206,9 @@ const TocEl: React.FC<TocProps> = (props) => {
       </>
       }
     </nav>
-  )
-}
+  );
+};
 
-const Toc = React.memo(TocEl, (prev, next) => prev.pathname === next.pathname)
+const Toc = React.memo(TocEl, (prev, next) => prev.pathname === next.pathname);
 
-export default Toc
+export default Toc;

--- a/gatsby-theme-oi-wiki/src/components/Toc/styles.ts
+++ b/gatsby-theme-oi-wiki/src/components/Toc/styles.ts
@@ -1,5 +1,5 @@
-import { makeStyles } from '@material-ui/core/styles'
-import { scrollbarStyle } from '../../styles/scrollbar'
+import { makeStyles } from '@material-ui/core/styles';
+import { scrollbarStyle } from '../../styles/scrollbar';
 
 export const useStyles = makeStyles((theme) => ({
   main: scrollbarStyle(theme, {
@@ -26,4 +26,4 @@ export const useStyles = makeStyles((theme) => ({
     marginTop: theme.spacing(2),
     paddingLeft: theme.spacing(1.5),
   },
-}))
+}));

--- a/gatsby-theme-oi-wiki/src/lib/MDRenderer.tsx
+++ b/gatsby-theme-oi-wiki/src/lib/MDRenderer.tsx
@@ -1,7 +1,7 @@
-import React from 'react'
-import { unified } from 'unified'
-import rehypeReact from 'rehype-react'
-import { Root } from 'hast'
+import React from 'react';
+import { unified } from 'unified';
+import rehypeReact from 'rehype-react';
+import { Root } from 'hast';
 
 export interface MDRendererProps {
   components: Record<string, any>;
@@ -12,9 +12,9 @@ const MDRenderer: React.FC<MDRendererProps> = (props) => {
   const processor = unified().use(rehypeReact, {
     createElement: React.createElement,
     components: props.components,
-  })
+  });
 
-  return processor.stringify(props.htmlAst) as never as JSX.Element
-}
+  return processor.stringify(props.htmlAst) as never as JSX.Element;
+};
 
-export default React.memo(MDRenderer, () => true)
+export default React.memo(MDRenderer, () => true);

--- a/gatsby-theme-oi-wiki/src/lib/play/codeLang.ts
+++ b/gatsby-theme-oi-wiki/src/lib/play/codeLang.ts
@@ -8,7 +8,7 @@ export const langModeMap = Object.freeze({
   'C++17': 'c_cpp',
   'C++20': 'c_cpp',
   Python3: 'python',
-})
+});
 
-export const langList = Object.keys(langModeMap)
+export const langList = Object.keys(langModeMap);
 export type LangType = keyof typeof langModeMap

--- a/gatsby-theme-oi-wiki/src/lib/play/useRunner.ts
+++ b/gatsby-theme-oi-wiki/src/lib/play/useRunner.ts
@@ -1,9 +1,9 @@
 /* eslint-disable camelcase */
-import type { AxiosResponse } from 'axios'
-import axios from 'axios'
-import has from 'lodash/has'
-import { useState } from 'react'
-import type { LangType } from './codeLang'
+import type { AxiosResponse } from 'axios';
+import axios from 'axios';
+import has from 'lodash/has';
+import { useState } from 'react';
+import type { LangType } from './codeLang';
 
 export interface RunnerApiRequestData {
   code: string
@@ -32,7 +32,7 @@ const responseKeyTransformMap = {
   time_ms: 'time',
   memory_kb: 'memory',
   ce_info: 'ceInfo',
-} as const
+} as const;
 
 export type TransformedResponseData = {
   [K in keyof RunnerApiResponseData as K extends 'message'
@@ -50,19 +50,19 @@ function transformResponseData(
     .reduce((transformedData, key) => {
       const transformedKey = has(responseKeyTransformMap, key)
         ? responseKeyTransformMap[key as keyof typeof responseKeyTransformMap]
-        : key
+        : key;
       // This will raise error of ts
       // transformedData[transformedKey] = data[key as keyof RunnerApiResponseData]
-      Object.defineProperty(transformedData, transformedKey, { value: data[key as keyof RunnerApiResponseData] })
-      return transformedData
-    }, {} as TransformedResponseData)
+      Object.defineProperty(transformedData, transformedKey, { value: data[key as keyof RunnerApiResponseData] });
+      return transformedData;
+    }, {} as TransformedResponseData);
 }
 
 function responseDataGuard (data: any): data is RunnerApiResponseData {
-  return typeof data.message === 'string'
+  return typeof data.message === 'string';
 }
 
-export const runnerApi = 'https://api2.duck-ac.cn/259ea31bf8ab6b59/duck-api/run'
+export const runnerApi = 'https://api2.duck-ac.cn/259ea31bf8ab6b59/duck-api/run';
 
 export function useRunner (
   req: RunnerApiRequestData,
@@ -72,10 +72,10 @@ export function useRunner (
   sendRunnerReq: () => void
   waiting: boolean
 } {
-  const [waiting, setWaiting] = useState(false)
+  const [waiting, setWaiting] = useState(false);
 
   const sendRunnerReq = (): void => {
-    setWaiting(true)
+    setWaiting(true);
 
     axios
       .request({
@@ -85,40 +85,40 @@ export function useRunner (
       })
       .then(({ data }) => {
         if (!responseDataGuard(data)) {
-          throw Error(`Incompatible response data format: ${data}`)
+          throw Error(`Incompatible response data format: ${data}`);
         }
         if (data.message === 'OK') {
-          if (onResponse) onResponse(transformResponseData(data))
+          if (onResponse) onResponse(transformResponseData(data));
         } else {
-          throw new Error(data.message)
+          throw new Error(data.message);
         }
       })
       .catch((err) => {
         // TODO: mark err as unknown for better type safety
         // https://github.com/microsoft/TypeScript/pull/41013
-        let msg = String(err)
+        let msg = String(err);
 
         function errResponseGuard(
           err: unknown,
         ): err is { response: AxiosResponse } {
-          return has(err, 'response')
+          return has(err, 'response');
         }
         if (errResponseGuard(err)) {
-          msg = `Server responded ${err.response.data} with code ${err.response.status}`
+          msg = `Server responded ${err.response.data} with code ${err.response.status}`;
         } else if (has(err, 'request')) {
-          msg = 'No response from server'
+          msg = 'No response from server';
         } else if (err instanceof Error) {
-          msg = err.message
+          msg = err.message;
         }
 
-        if (onError) onError(msg)
+        if (onError) onError(msg);
         else if (process.env.NODE_ENV === 'development')
-          console.error(`Unhandled exception in code runner: ${err}`)
+          console.error(`Unhandled exception in code runner: ${err}`);
       })
       .finally(() => {
-        setWaiting(false)
-      })
-  }
+        setWaiting(false);
+      });
+  };
 
-  return { sendRunnerReq, waiting }
+  return { sendRunnerReq, waiting };
 }

--- a/gatsby-theme-oi-wiki/src/lib/relativeTime.ts
+++ b/gatsby-theme-oi-wiki/src/lib/relativeTime.ts
@@ -7,27 +7,27 @@
  * @return {string}  string
  */
 export default function timeDifference (current: number, previous: number): string {
-  const msPerMinute = 60 * 1000
-  const msPerHour = msPerMinute * 60
-  const msPerDay = msPerHour * 24
-  const msPerMonth = msPerDay * 30
-  const msPerYear = msPerDay * 365
+  const msPerMinute = 60 * 1000;
+  const msPerHour = msPerMinute * 60;
+  const msPerDay = msPerHour * 24;
+  const msPerMonth = msPerDay * 30;
+  const msPerYear = msPerDay * 365;
 
-  const elapsed = current - previous
+  const elapsed = current - previous;
 
   if (elapsed < msPerMinute / 2) {
-    return '刚刚'
+    return '刚刚';
   }
   if (elapsed < msPerMinute) {
-    return Math.round(elapsed / 1000) + ' 秒前'
+    return Math.round(elapsed / 1000) + ' 秒前';
   } else if (elapsed < msPerHour) {
-    return Math.round(elapsed / msPerMinute) + ' 分钟前'
+    return Math.round(elapsed / msPerMinute) + ' 分钟前';
   } else if (elapsed < msPerDay) {
-    return Math.round(elapsed / msPerHour) + ' 小时前'
+    return Math.round(elapsed / msPerHour) + ' 小时前';
   } else if (elapsed < msPerMonth) {
-    return `约 ${Math.round(elapsed / msPerDay)} 天前`
+    return `约 ${Math.round(elapsed / msPerDay)} 天前`;
   } else if (elapsed < msPerYear) {
-    return `约 ${Math.round(elapsed / msPerMonth)} 个月前`
+    return `约 ${Math.round(elapsed / msPerMonth)} 个月前`;
   }
-  return `约 ${Math.round(elapsed / msPerYear)} 年前`
+  return `约 ${Math.round(elapsed / msPerYear)} 年前`;
 }

--- a/gatsby-theme-oi-wiki/src/lib/smoothScroll.ts
+++ b/gatsby-theme-oi-wiki/src/lib/smoothScroll.ts
@@ -1,4 +1,4 @@
-import { Nullable } from '../types/common'
+import { Nullable } from '../types/common';
 
 export type SmoothScrollToType = ((yCoordinate: number, duration?: number, optimizeForSmallScreen?: boolean) => void)
 
@@ -27,17 +27,17 @@ export type SmoothScrollToType = ((yCoordinate: number, duration?: number, optim
  * plot(res, xmin=0)
  * */
 const getDisplacement = (progress: number): number => {
-  if (progress < 0) return 0
+  if (progress < 0) return 0;
 
   function f (t: number): number {
     return 1 + 0.25 * (
       1.1622776601683795 * Math.exp((-10 / 3) * t * 8.16227766016838) -
       5.16227766016838 * Math.exp((10 / 3) * t * -1.8377223398316205)
-    )
+    );
   }
 
-  return f(progress) * 1.00283
-}
+  return f(progress) * 1.00283;
+};
 
 /**
  *
@@ -46,40 +46,40 @@ const getDisplacement = (progress: number): number => {
  * @param optimizeForSmallScreen 为小屏幕使用 CSS 动画来解决性能问题
  */
 const smoothScrollTo: SmoothScrollToType = (yCoordinate, duration = -1, optimizeForSmallScreen = true) => {
-  const maximumCoordinate = document.body.scrollHeight - window.innerHeight
-  const offset = Math.min(yCoordinate, maximumCoordinate) - window.scrollY
-  const isSmallScreen = window.innerWidth <= 600
+  const maximumCoordinate = document.body.scrollHeight - window.innerHeight;
+  const offset = Math.min(yCoordinate, maximumCoordinate) - window.scrollY;
+  const isSmallScreen = window.innerWidth <= 600;
 
   if (isSmallScreen && optimizeForSmallScreen) {
-    window.scrollTo({ top: yCoordinate, behavior: 'smooth' })
-    return
+    window.scrollTo({ top: yCoordinate, behavior: 'smooth' });
+    return;
   }
 
   if (duration === -1) {
-    const absOffset = Math.abs(offset)
-    duration = 300 + Math.sqrt(2 * absOffset / 0.02)
+    const absOffset = Math.abs(offset);
+    duration = 300 + Math.sqrt(2 * absOffset / 0.02);
   }
 
-  const startTime = performance.now()
-  const startPosition = window.scrollY
-  const el: Nullable<HTMLDivElement> = document.querySelector('.maincontentdiv')
+  const startTime = performance.now();
+  const startPosition = window.scrollY;
+  const el: Nullable<HTMLDivElement> = document.querySelector('.maincontentdiv');
 
-  if (!el) throw new Error('.maincontentdiv 缺失')
+  if (!el) throw new Error('.maincontentdiv 缺失');
 
-  window.scrollTo(0, yCoordinate)
+  window.scrollTo(0, yCoordinate);
   const performAnimation = (time: number): void => {
     if (time - startTime > duration) {
-      el.style.transform = ''
-      return
+      el.style.transform = '';
+      return;
     }
 
-    const displacement = offset * getDisplacement((time - startTime) / duration)
+    const displacement = offset * getDisplacement((time - startTime) / duration);
     // window.scrollTo(0, startPosition + displacement)
-    el.style.transform = `translateY(${yCoordinate - startPosition - displacement}px)`
-    requestAnimationFrame(performAnimation)
-  }
+    el.style.transform = `translateY(${yCoordinate - startPosition - displacement}px)`;
+    requestAnimationFrame(performAnimation);
+  };
 
-  requestAnimationFrame(performAnimation)
-}
+  requestAnimationFrame(performAnimation);
+};
 
-export default smoothScrollTo
+export default smoothScrollTo;

--- a/gatsby-theme-oi-wiki/src/lib/trailingSlash.ts
+++ b/gatsby-theme-oi-wiki/src/lib/trailingSlash.ts
@@ -1,3 +1,3 @@
 export default function trimTrailingSlash(str?: string): string {
-  return str?.replace(/\/$/, '') ?? ''
+  return str?.replace(/\/$/, '') ?? '';
 }

--- a/gatsby-theme-oi-wiki/src/lib/useDarkMode.ts
+++ b/gatsby-theme-oi-wiki/src/lib/useDarkMode.ts
@@ -1,23 +1,23 @@
-import useMediaQuery from '@material-ui/core/useMediaQuery'
-import { useSetting } from './useSetting'
+import useMediaQuery from '@material-ui/core/useMediaQuery';
+import { useSetting } from './useSetting';
 
 export default function useDarkMode (): boolean {
-  const [setting] = useSetting()
-  const prefersDarkMode = useMediaQuery('(prefers-color-scheme: dark)', { noSsr: true })
+  const [setting] = useSetting();
+  const prefersDarkMode = useMediaQuery('(prefers-color-scheme: dark)', { noSsr: true });
   // noSsr: when it is false(by default), preact is enabled and user prefers dark mode,
   // useMediaQuery will return twice. Firstly false, then true. That leads to flicker whenever the route changes.
   // According to the documentation https://material-ui.com/zh/components/use-media-query/#usemediaquery-query-options-matches
   // , it should be false if you are using server side rendering.
   // However, I found that ssr still works well even if i set it to true. Therefore I enable noSsr as a workaround.
-  let enableDark: boolean
+  let enableDark: boolean;
   if (setting.darkMode.type === 'always-on') {
-    enableDark = true
+    enableDark = true;
   } else if (setting.darkMode.type === 'always-off') {
-    enableDark = false
+    enableDark = false;
   } else if (setting.darkMode.type === 'user-preference') {
-    enableDark = prefersDarkMode
+    enableDark = prefersDarkMode;
   } else {
-    enableDark = prefersDarkMode // TODO: to be implemented
+    enableDark = prefersDarkMode; // TODO: to be implemented
   }
-  return enableDark
+  return enableDark;
 }

--- a/gatsby-theme-oi-wiki/src/lib/useSetting.ts
+++ b/gatsby-theme-oi-wiki/src/lib/useSetting.ts
@@ -1,6 +1,6 @@
-import usePersistedState from 'use-persisted-state'
-import { LabeledPaletteColor } from '../styles/colors'
-import merge from 'deepmerge'
+import usePersistedState from 'use-persisted-state';
+import { LabeledPaletteColor } from '../styles/colors';
+import merge from 'deepmerge';
 
 export interface Settings {
   darkMode: {
@@ -32,7 +32,7 @@ const defaultSettings: Settings = {
     secondary: '3', // Margatriod Magenta
     fallbackMonoFont: false,
   },
-}
+};
 
 // https://stackoverflow.com/questions/41980195/recursive-partialt-in-typescript
 // 第一个回答会让 linter unhappy, 所以魔改了一下
@@ -41,12 +41,12 @@ type RecursivePartial<T> = {
 };
 
 export const useSetting = (): [Settings, (s: RecursivePartial<Settings>) => void] => {
-  const [settings, setSettings] = usePersistedState('settings')(defaultSettings)
+  const [settings, setSettings] = usePersistedState('settings')(defaultSettings);
 
   const updateSetting = (newSettings: RecursivePartial<Settings>): void => {
-    const finalSettings = merge.all([defaultSettings, settings, newSettings]) as Settings
-    setSettings(finalSettings)
-    window !== undefined && window['onthemechange'](finalSettings)
-  }
-  return [settings, updateSetting]
-}
+    const finalSettings = merge.all([defaultSettings, settings, newSettings]) as Settings;
+    setSettings(finalSettings);
+    window !== undefined && window['onthemechange'](finalSettings);
+  };
+  return [settings, updateSetting];
+};

--- a/gatsby-theme-oi-wiki/src/lib/useThrottledOnScroll.ts
+++ b/gatsby-theme-oi-wiki/src/lib/useThrottledOnScroll.ts
@@ -1,23 +1,23 @@
-import { useEffect, useMemo } from 'react'
-import { noopNull, throttle } from '../utils/common'
+import { useEffect, useMemo } from 'react';
+import { noopNull, throttle } from '../utils/common';
 
 const useThrottledOnScroll = (callback: (...agrs: any) => any, delay: number): void => {
   const throttledCallback = useMemo(
     () => (callback ? throttle(callback, delay) : noopNull),
     [callback, delay],
-  )
+  );
 
   useEffect(() => {
-    if (throttledCallback === noopNull) return
+    if (throttledCallback === noopNull) return;
 
-    window.addEventListener('scroll', throttledCallback, { passive: true })
+    window.addEventListener('scroll', throttledCallback, { passive: true });
 
     return () => {
       window.removeEventListener('scroll', throttledCallback, { passive: true })
 
-      ;(throttledCallback as ReturnType<typeof throttle>).cancel()
-    }
-  }, [throttledCallback])
-}
+      ;(throttledCallback as ReturnType<typeof throttle>).cancel();
+    };
+  }, [throttledCallback]);
+};
 
-export default useThrottledOnScroll
+export default useThrottledOnScroll;

--- a/gatsby-theme-oi-wiki/src/pages/404.tsx
+++ b/gatsby-theme-oi-wiki/src/pages/404.tsx
@@ -1,5 +1,5 @@
-import React from 'react'
-import StyledLayout from '../components/StyledLayout'
+import React from 'react';
+import StyledLayout from '../components/StyledLayout';
 
 const page: React.FC<{ location: Location }> = ({ location }) => (
   <StyledLayout location={location} noEdit={true} title="404" noComment={false}>
@@ -12,6 +12,6 @@ const page: React.FC<{ location: Location }> = ({ location }) => (
       </div>
     </div>
   </StyledLayout>
-)
+);
 
-export default page
+export default page;

--- a/gatsby-theme-oi-wiki/src/pages/pages.tsx
+++ b/gatsby-theme-oi-wiki/src/pages/pages.tsx
@@ -1,16 +1,16 @@
-import { Card, CardActions, CardContent, Grid, TextField, Typography, useMediaQuery } from '@material-ui/core'
-import { useTheme } from '@material-ui/core/styles'
-import Autocomplete from '@material-ui/lab/Autocomplete'
-import match from 'autosuggest-highlight/match'
-import parse from 'autosuggest-highlight/parse'
-import times from 'lodash/times'
-import { graphql, useStaticQuery } from 'gatsby'
-import React, { useState } from 'react'
+import { Card, CardActions, CardContent, Grid, TextField, Typography, useMediaQuery } from '@material-ui/core';
+import { useTheme } from '@material-ui/core/styles';
+import Autocomplete from '@material-ui/lab/Autocomplete';
+import match from 'autosuggest-highlight/match';
+import parse from 'autosuggest-highlight/parse';
+import times from 'lodash/times';
+import { graphql, useStaticQuery } from 'gatsby';
+import React, { useState } from 'react';
 
-import { SmartLink } from '../components/Link'
-import Tags from '../components/Tags'
-import StyledLayout from '../components/StyledLayout'
-import { DeepRequiredNonNull, DeepWriteable } from '../types/common'
+import { SmartLink } from '../components/Link';
+import Tags from '../components/Tags';
+import StyledLayout from '../components/StyledLayout';
+import { DeepRequiredNonNull, DeepWriteable } from '../types/common';
 
 interface PageItemInfo {
   id: string;
@@ -27,7 +27,7 @@ const PageItem: React.FC<PageItemProps> = (props) => {
     id,
     frontmatter: { title, tags },
     fields: { slug: link },
-  } = props
+  } = props;
 
   return (
     <Grid item key={id}>
@@ -42,13 +42,13 @@ const PageItem: React.FC<PageItemProps> = (props) => {
         </CardActions>
       </Card>
     </Grid>
-  )
-}
+  );
+};
 
 function matchTags(pageTags: string[], selectedTags: string[]): boolean {
-  if (selectedTags.length === 0) return true
-  else if (!pageTags) return false
-  else return selectedTags.every((v) => pageTags.includes(v))
+  if (selectedTags.length === 0) return true;
+  else if (!pageTags) return false;
+  else return selectedTags.every((v) => pageTags.includes(v));
 }
 
 interface ColumnProps {
@@ -60,7 +60,7 @@ const Column: React.FC<ColumnProps> = ({ items, linkComponent }) => (
   <Grid container item xs direction="column" spacing={2}>
     {items.map(x => <PageItem key={x.id} {...x} linkComponent={linkComponent}/>)}
   </Grid>
-)
+);
 
 interface GridItemsProps {
   filteredItems: ColumnProps['items'];
@@ -68,17 +68,17 @@ interface GridItemsProps {
 }
 
 const GridItems: React.FC<GridItemsProps> = (props) => {
-  const theme = useTheme()
-  const { filteredItems } = props
-  const upStatus = theme.breakpoints.up
+  const theme = useTheme();
+  const { filteredItems } = props;
+  const upStatus = theme.breakpoints.up;
   const upList = [
     useMediaQuery(upStatus('xl')),
     useMediaQuery(upStatus('lg')),
     useMediaQuery(upStatus('md')),
     useMediaQuery(upStatus('sm')),
     true,
-  ]
-  const columnCount = 5 - upList.indexOf(true)
+  ];
+  const columnCount = 5 - upList.indexOf(true);
 
   return (
     <>
@@ -90,8 +90,8 @@ const GridItems: React.FC<GridItemsProps> = (props) => {
         />,
       )}
     </>
-  )
-}
+  );
+};
 
 export interface BlogIndexProps {
   location: Location;
@@ -118,13 +118,13 @@ const BlogIndex: React.FC<BlogIndexProps> = (props) => {
           totalCount
         }
       }
-    }`) as DeepWriteable<DeepRequiredNonNull<GatsbyTypes.BlogIndexQuery>>
+    }`) as DeepWriteable<DeepRequiredNonNull<GatsbyTypes.BlogIndexQuery>>;
 
-  const { location } = props
-  const articles = edges.map(x => x.node)
-  const tags = group.map(({ fieldValue }) => fieldValue)
-  const [selectedTags, setSelectedTags] = useState<string[]>([])
-  const filteredItems = articles.filter((v) => !!v.frontmatter.title && matchTags(v.frontmatter.tags, selectedTags))
+  const { location } = props;
+  const articles = edges.map(x => x.node);
+  const tags = group.map(({ fieldValue }) => fieldValue);
+  const [selectedTags, setSelectedTags] = useState<string[]>([]);
+  const filteredItems = articles.filter((v) => !!v.frontmatter.title && matchTags(v.frontmatter.tags, selectedTags));
 
   return (
     <StyledLayout
@@ -140,7 +140,7 @@ const BlogIndex: React.FC<BlogIndexProps> = (props) => {
           <Autocomplete
             value={selectedTags}
             onChange={(_, v) => {
-              setSelectedTags(v)
+              setSelectedTags(v);
             }}
             multiple={true}
             disableCloseOnSelect={true}
@@ -148,8 +148,8 @@ const BlogIndex: React.FC<BlogIndexProps> = (props) => {
             options={tags}
             getOptionLabel={(option) => option}
             renderOption={(option, { inputValue }) => {
-              const matches = match(option, inputValue)
-              const parts = parse(option, matches)
+              const matches = match(option, inputValue);
+              const parts = parse(option, matches);
               return parts.map((part, index) => (
                 <span
                   key={index}
@@ -157,7 +157,7 @@ const BlogIndex: React.FC<BlogIndexProps> = (props) => {
                 >
                   {part.text}
                 </span>
-              ))
+              ));
             }}
             renderInput={(params) => (
               <TextField
@@ -175,7 +175,7 @@ const BlogIndex: React.FC<BlogIndexProps> = (props) => {
         </Grid>
       </Grid>
     </StyledLayout>
-  )
-}
+  );
+};
 
-export default BlogIndex
+export default BlogIndex;

--- a/gatsby-theme-oi-wiki/src/pages/play.tsx
+++ b/gatsby-theme-oi-wiki/src/pages/play.tsx
@@ -9,20 +9,20 @@ import {
   Link,
   makeStyles,
   Switch,
-} from '@material-ui/core'
-import PlayArrow from '@material-ui/icons/PlayArrow'
-import type { PageProps } from 'gatsby'
-import { graphql, useStaticQuery } from 'gatsby'
-import React, { useCallback, useRef, useState } from 'react'
-import CodeEditor from '../components/CodeEditor'
-import type { IndicatorProps } from '../components/Indicator'
-import Indicator from '../components/Indicator'
-import CodeLangMenu from '../components/CodeLangMenu'
-import Output from '../components/Output'
-import Layout from '../components/StyledLayout'
-import type { LangType } from '../lib/play/codeLang'
-import type { TransformedResponseData } from '../lib/play/useRunner'
-import { useRunner } from '../lib/play/useRunner'
+} from '@material-ui/core';
+import PlayArrow from '@material-ui/icons/PlayArrow';
+import type { PageProps } from 'gatsby';
+import { graphql, useStaticQuery } from 'gatsby';
+import React, { useCallback, useRef, useState } from 'react';
+import CodeEditor from '../components/CodeEditor';
+import type { IndicatorProps } from '../components/Indicator';
+import Indicator from '../components/Indicator';
+import CodeLangMenu from '../components/CodeLangMenu';
+import Output from '../components/Output';
+import Layout from '../components/StyledLayout';
+import type { LangType } from '../lib/play/codeLang';
+import type { TransformedResponseData } from '../lib/play/useRunner';
+import { useRunner } from '../lib/play/useRunner';
 
 const useStyles = makeStyles((theme) => ({
   langMenu: {
@@ -57,7 +57,7 @@ const useStyles = makeStyles((theme) => ({
       color: '#FC6012',
     },
   },
-}))
+}));
 
 export type PlaygroundLocationState = Partial<{
   lang: LangType
@@ -69,20 +69,20 @@ const Playground: React.FC<
   PageProps<unknown, unknown, PlaygroundLocationState>
 > = ({ location }) => {
   // state maybe undefined/null in gatsby build
-  const locState = location.state ?? {}
+  const locState = location.state ?? {};
 
-  const classes = useStyles()
+  const classes = useStyles();
 
-  const [lang, setLang] = useState<LangType>(locState.lang ?? 'C++')
-  const [o2, setO2] = useState(false)
+  const [lang, setLang] = useState<LangType>(locState.lang ?? 'C++');
+  const [o2, setO2] = useState(false);
 
-  const [code, setCode] = useState(locState.code ?? '')
-  const [input, setInput] = useState(locState.input ?? '')
-  const [output, setOutput] = useState<TransformedResponseData | null>(null)
+  const [code, setCode] = useState(locState.code ?? '');
+  const [input, setInput] = useState(locState.input ?? '');
+  const [output, setOutput] = useState<TransformedResponseData | null>(null);
 
-  const [runInfo, setRunInfo] = useState<IndicatorProps | null>(null)
+  const [runInfo, setRunInfo] = useState<IndicatorProps | null>(null);
 
-  const outputRef = useRef<HTMLElement>(null)
+  const outputRef = useRef<HTMLElement>(null);
 
   const judgeDuckImgUrl: string = useStaticQuery(graphql`
     {
@@ -94,31 +94,31 @@ const Playground: React.FC<
         }
       }
     }
-  `).allFile.edges[0].node.publicURL
+  `).allFile.edges[0].node.publicURL;
 
   const runCodeCb = useCallback((data: TransformedResponseData) => {
-    setOutput(data)
+    setOutput(data);
     setRunInfo(
       data.status === 'Run Finished'
         ? { type: 'success', msg: 'Success' }
         : { type: 'warning', msg: 'Checkout output for error details' },
-    )
+    );
 
-    outputRef.current?.scrollIntoView({ behavior: 'smooth' })
-  }, [])
+    outputRef.current?.scrollIntoView({ behavior: 'smooth' });
+  }, []);
   const errorCb = useCallback((msg: string) => {
-    setRunInfo({ type: 'error', msg })
-  }, [])
+    setRunInfo({ type: 'error', msg });
+  }, []);
   const { sendRunnerReq, waiting } = useRunner(
     { stdin: input, code, language: lang, flags: o2 ? '-O2' : '' },
     runCodeCb,
     errorCb,
-  )
+  );
 
   const handleRunClick = useCallback(() => {
-    setRunInfo(null)
-    sendRunnerReq()
-  }, [sendRunnerReq])
+    setRunInfo(null);
+    sendRunnerReq();
+  }, [sendRunnerReq]);
 
   return (
     <Layout
@@ -170,7 +170,7 @@ const Playground: React.FC<
                 size="small"
                 checked={o2}
                 onChange={(e) => {
-                  setO2(e.target.checked)
+                  setO2(e.target.checked);
                 }}
               />
             }
@@ -190,7 +190,7 @@ const Playground: React.FC<
             title="代码"
             value={code}
             onChange={(val) => {
-              setCode(val)
+              setCode(val);
             }}
           />
         </Grid>
@@ -200,7 +200,7 @@ const Playground: React.FC<
               title="输入"
               value={input}
               onChange={(val) => {
-                setInput(val)
+                setInput(val);
               }}
             />
           </Grid>
@@ -222,7 +222,7 @@ const Playground: React.FC<
         </Link>
       </div>
     </Layout>
-  )
-}
+  );
+};
 
-export default Playground
+export default Playground;

--- a/gatsby-theme-oi-wiki/src/pages/settings.tsx
+++ b/gatsby-theme-oi-wiki/src/pages/settings.tsx
@@ -8,11 +8,11 @@ import {
   Radio,
   RadioGroup,
   Switch,
-} from '@material-ui/core'
-import React from 'react'
-import colors, { LabeledPaletteColor } from '../styles/colors'
-import { Settings, useSetting } from '../lib/useSetting'
-import StyledLayout from '../components/StyledLayout'
+} from '@material-ui/core';
+import React from 'react';
+import colors, { LabeledPaletteColor } from '../styles/colors';
+import { Settings, useSetting } from '../lib/useSetting';
+import StyledLayout from '../components/StyledLayout';
 
 const useStyles = makeStyles((theme) => ({
   root: (props: LabeledPaletteColor | Record<string, never>) => ({
@@ -37,7 +37,7 @@ const useStyles = makeStyles((theme) => ({
     left: '.3em',
     width: 'calc(100% - .6em)',
   },
-}))
+}));
 
 interface ColorButtonProps {
   data: LabeledPaletteColor
@@ -45,8 +45,8 @@ interface ColorButtonProps {
 }
 
 const ColorButton: React.FC<ColorButtonProps> = (props) => {
-  const { data, onClick } = props
-  const classes = useStyles(data.main === 'auto' ? {} : data)
+  const { data, onClick } = props;
+  const classes = useStyles(data.main === 'auto' ? {} : data);
   return (
     <Grid item>
       <Button
@@ -56,32 +56,32 @@ const ColorButton: React.FC<ColorButtonProps> = (props) => {
         {props.data.desc}
       </Button>
     </Grid>
-  )
-}
+  );
+};
 
 type SettingsPageProps = {
   location: Location
 }
 const SettingsPage: React.FC<SettingsPageProps> = (props: SettingsPageProps) => {
-  const { location } = props
-  const [settings, updateSetting] = useSetting()
+  const { location } = props;
+  const [settings, updateSetting] = useSetting();
 
   const onNavColorBtnClick = (c: LabeledPaletteColor): void => {
     updateSetting({
       theme: {
         primary: c.main === 'auto' ? null : c,
       },
-    })
-  }
+    });
+  };
 
   const onSecondaryColorBtnClick = (c: LabeledPaletteColor): void => {
-    if (c.main === 'auto') throw new Error('invalid color')
+    if (c.main === 'auto') throw new Error('invalid color');
     updateSetting({
       theme: {
         secondary: c.id,
       },
-    })
-  }
+    });
+  };
 
   return (
     <StyledLayout
@@ -103,7 +103,7 @@ const SettingsPage: React.FC<SettingsPageProps> = (props: SettingsPageProps) => 
                   darkMode: {
                     type: (e.target.value as Settings['darkMode']['type']),
                   },
-                })
+                });
               }}
             >
               <FormControlLabel value="user-preference" control={<Radio/>} label="跟随系统"/>
@@ -125,7 +125,7 @@ const SettingsPage: React.FC<SettingsPageProps> = (props: SettingsPageProps) => 
                               animation: {
                                 smoothScroll: e.target.checked,
                               },
-                            })
+                            });
                           }
                           }
                   />
@@ -148,7 +148,7 @@ const SettingsPage: React.FC<SettingsPageProps> = (props: SettingsPageProps) => 
                               theme: {
                                 fallbackMonoFont: e.target.checked,
                               },
-                            })
+                            });
                           }
                           }
                   />
@@ -172,7 +172,7 @@ const SettingsPage: React.FC<SettingsPageProps> = (props: SettingsPageProps) => 
         </Grid>
       </Grid>
     </StyledLayout>
-  )
-}
+  );
+};
 
-export default SettingsPage
+export default SettingsPage;

--- a/gatsby-theme-oi-wiki/src/pages/tags.tsx
+++ b/gatsby-theme-oi-wiki/src/pages/tags.tsx
@@ -1,16 +1,16 @@
-import Chip from '@material-ui/core/Chip'
-import { makeStyles } from '@material-ui/core/styles'
-import { graphql, useStaticQuery } from 'gatsby'
-import kebabCase from 'lodash/kebabCase'
-import React from 'react'
-import StyledLayout from '../components/StyledLayout'
-import { DeepRequiredNonNull, DeepWriteable } from '../types/common'
+import Chip from '@material-ui/core/Chip';
+import { makeStyles } from '@material-ui/core/styles';
+import { graphql, useStaticQuery } from 'gatsby';
+import kebabCase from 'lodash/kebabCase';
+import React from 'react';
+import StyledLayout from '../components/StyledLayout';
+import { DeepRequiredNonNull, DeepWriteable } from '../types/common';
 
 const useStyles = makeStyles((theme) => ({
   chip: {
     margin: theme.spacing(0.5),
   },
-}))
+}));
 
 export interface TagsPageProps {
   location: Location
@@ -33,12 +33,12 @@ const TagsPage: React.FC<TagsPageProps> = (props) => {
         }
       }
     }
-  `) as DeepWriteable<DeepRequiredNonNull<GatsbyTypes.TagsQuery>>
+  `) as DeepWriteable<DeepRequiredNonNull<GatsbyTypes.TagsQuery>>;
 
-  const classes = useStyles()
-  const { location } = props
+  const classes = useStyles();
+  const { location } = props;
 
-  group.sort((a, b) => b.totalCount - a.totalCount)
+  group.sort((a, b) => b.totalCount - a.totalCount);
 
   return (
     <StyledLayout location={location} noMeta={true} title="标签页">
@@ -56,7 +56,7 @@ const TagsPage: React.FC<TagsPageProps> = (props) => {
         ))}
       </div>
     </StyledLayout>
-  )
-}
+  );
+};
 
-export default TagsPage
+export default TagsPage;

--- a/gatsby-theme-oi-wiki/src/static/extra.js
+++ b/gatsby-theme-oi-wiki/src/static/extra.js
@@ -12,4 +12,4 @@ MathJax.Hub.Config({
   svg: {
     fontCache: 'global',
   },
-})
+});

--- a/gatsby-theme-oi-wiki/src/styles/colors.ts
+++ b/gatsby-theme-oi-wiki/src/styles/colors.ts
@@ -3,18 +3,18 @@ import {
   darken,
   getContrastRatio,
   SimplePaletteColorOptions,
-} from '@material-ui/core/styles'
+} from '@material-ui/core/styles';
 
 function addLightOrDark (obj, typ: string, tonalOffset): SimplePaletteColorOptions {
-  const tonalOffsetLight = tonalOffset.light || tonalOffset
-  const tonalOffsetDark = tonalOffset.dark || tonalOffset * 1.5
+  const tonalOffsetLight = tonalOffset.light || tonalOffset;
+  const tonalOffsetDark = tonalOffset.dark || tonalOffset * 1.5;
 
-  if (obj[typ]) return
+  if (obj[typ]) return;
 
   if (typ === 'light') {
-    obj.light = lighten(obj.main, tonalOffsetLight)
+    obj.light = lighten(obj.main, tonalOffsetLight);
   } else if (typ === 'dark') {
-    obj.dark = darken(obj.main, tonalOffsetDark)
+    obj.dark = darken(obj.main, tonalOffsetDark);
   }
 }
 
@@ -24,26 +24,26 @@ function addLightOrDark (obj, typ: string, tonalOffset): SimplePaletteColorOptio
 function getContrastText (background, contrastThreshold) : string {
   const contrastText = getContrastRatio(background, '#fff') >= contrastThreshold
     ? '#fff'
-    : 'rgba(0, 0, 0, 0.87)'
+    : 'rgba(0, 0, 0, 0.87)';
 
-  return contrastText
+  return contrastText;
 }
 
 function createPaletteColor (color: string, tonalOffset: number): SimplePaletteColorOptions {
-  const contrastThreshold = 3
+  const contrastThreshold = 3;
   const obj: SimplePaletteColorOptions = {
     main: color,
-  }
+  };
   if (color === 'auto') {
-    obj.light = 'auto'
-    obj.dark = 'auto'
-    obj.contrastText = 'auto'
-    return obj
+    obj.light = 'auto';
+    obj.dark = 'auto';
+    obj.contrastText = 'auto';
+    return obj;
   }
-  addLightOrDark(obj, 'light', tonalOffset)
-  addLightOrDark(obj, 'dark', tonalOffset)
-  obj.contrastText = getContrastText(obj.main, contrastThreshold)
-  return obj
+  addLightOrDark(obj, 'light', tonalOffset);
+  addLightOrDark(obj, 'dark', tonalOffset);
+  obj.contrastText = getContrastText(obj.main, contrastThreshold);
+  return obj;
 }
 
 const colors: Array<{desc: string, color: string}> = [
@@ -70,7 +70,7 @@ const colors: Array<{desc: string, color: string}> = [
   { color: '#795548', desc: 'Brown' },
   { color: '#757575', desc: 'Grey' },
   { color: '#546e7a', desc: 'Blue Grey' },
-]
+];
 
 export interface LabeledPaletteColor extends SimplePaletteColorOptions {
   desc: string;
@@ -81,6 +81,6 @@ const paletteColors: Array<LabeledPaletteColor> = colors.map((c, i) => ({
   ...createPaletteColor(c.color, 0.2),
   desc: c.desc,
   id: i.toString(),
-}))
+}));
 
-export default paletteColors
+export default paletteColors;

--- a/gatsby-theme-oi-wiki/src/styles/scrollbar.ts
+++ b/gatsby-theme-oi-wiki/src/styles/scrollbar.ts
@@ -1,16 +1,16 @@
-import grey from '@material-ui/core/colors/grey'
-import { alpha, Theme } from '@material-ui/core/styles'
-import { CSSProperties } from '@material-ui/core/styles/withStyles'
+import grey from '@material-ui/core/colors/grey';
+import { alpha, Theme } from '@material-ui/core/styles';
+import { CSSProperties } from '@material-ui/core/styles/withStyles';
 
 const scrollbarStyle = (theme: Theme, otherStyles: CSSProperties, width?: number): CSSProperties => {
-  const size = width || 0.4
+  const size = width || 0.4;
   const scrollbarWidth = {
     '&::-webkit-scrollbar': {
       // width relative to self font-size
       width: `${size}rem`,
       height: `${size}rem`,
     },
-  }
+  };
 
   return ({
     ...{
@@ -25,7 +25,7 @@ const scrollbarStyle = (theme: Theme, otherStyles: CSSProperties, width?: number
     },
     ...scrollbarWidth,
     ...otherStyles,
-  })
-}
+  });
+};
 
-export { scrollbarStyle }
+export { scrollbarStyle };

--- a/gatsby-theme-oi-wiki/src/templates/changelog.js
+++ b/gatsby-theme-oi-wiki/src/templates/changelog.js
@@ -6,18 +6,18 @@ import {
   TimelineItem,
   TimelineOppositeContent,
   TimelineSeparator,
-} from '@material-ui/lab'
-import { Divider, Paper, Typography } from '@material-ui/core'
-import { makeStyles } from '@material-ui/core/styles'
-import ArrowBackIos from '@material-ui/icons/ArrowBackIos'
-import Button from '@material-ui/core/Button'
-import lightBlue from '@material-ui/core/colors/lightBlue'
+} from '@material-ui/lab';
+import { Divider, Paper, Typography } from '@material-ui/core';
+import { makeStyles } from '@material-ui/core/styles';
+import ArrowBackIos from '@material-ui/icons/ArrowBackIos';
+import Button from '@material-ui/core/Button';
+import lightBlue from '@material-ui/core/colors/lightBlue';
 
-import React from 'react'
-import { Link as GatsbyLink } from 'gatsby'
-import Time from '../components/Time.tsx'
-import { SmartLink } from '../components/Link'
-import StyledLayout from '../components/StyledLayout'
+import React from 'react';
+import { Link as GatsbyLink } from 'gatsby';
+import Time from '../components/Time.tsx';
+import { SmartLink } from '../components/Link';
+import StyledLayout from '../components/StyledLayout';
 
 const useStyles = makeStyles((theme) => ({
   paper: {
@@ -63,15 +63,15 @@ const useStyles = makeStyles((theme) => ({
   backContainer: {
     marginTop: '30px',
   },
-}))
+}));
 
 const ChangeLog = ({ pageContext: { title, changelog, relativePath }, location }) => {
-  const classes = useStyles()
+  const classes = useStyles();
   return (
     <StyledLayout location={location} noMeta={true} title={`更新历史${title ? ` - ${title}` : ''}`}>
       <Timeline>
         {changelog.all.map((item, index) => {
-          const { hash, date, message, author_name: author } = item
+          const { hash, date, message, author_name: author } = item;
           return (
             <TimelineItem key={index + '#'}>
               <TimelineOppositeContent className={classes.timeBlock}>
@@ -102,7 +102,7 @@ const ChangeLog = ({ pageContext: { title, changelog, relativePath }, location }
                 </Paper>
               </TimelineContent>
             </TimelineItem>
-          )
+          );
         })}
         <TimelineItem>
           <TimelineOppositeContent className={classes.timeBlock}>
@@ -132,7 +132,7 @@ const ChangeLog = ({ pageContext: { title, changelog, relativePath }, location }
         </Button>
       </div>
     </StyledLayout>
-  )
-}
+  );
+};
 
-export default ChangeLog
+export default ChangeLog;

--- a/gatsby-theme-oi-wiki/src/templates/doc.js
+++ b/gatsby-theme-oi-wiki/src/templates/doc.js
@@ -1,9 +1,9 @@
-import { graphql } from 'gatsby'
-import React from 'react'
-import Mdx from '../components/Mdx'
+import { graphql } from 'gatsby';
+import React from 'react';
+import Mdx from '../components/Mdx';
 
 export default function MdxDoc({ data, location }) {
-  return <Mdx data={data} location={location}/>
+  return <Mdx data={data} location={location}/>;
 }
 
 export const query = graphql`
@@ -45,4 +45,4 @@ export const query = graphql`
       }
     }
   }
-`
+`;

--- a/gatsby-theme-oi-wiki/src/templates/tags.js
+++ b/gatsby-theme-oi-wiki/src/templates/tags.js
@@ -1,18 +1,18 @@
 // Components
-import { Button, List, ListItem, ListItemIcon, ListItemText, Typography } from '@material-ui/core'
+import { Button, List, ListItem, ListItemIcon, ListItemText, Typography } from '@material-ui/core';
 
-import BookIcon from '@material-ui/icons/Book'
-import ArrowBackIosIcon from '@material-ui/icons/ArrowBackIos'
+import BookIcon from '@material-ui/icons/Book';
+import ArrowBackIosIcon from '@material-ui/icons/ArrowBackIos';
 
-import { graphql } from 'gatsby'
-import PropTypes from 'prop-types'
-import React from 'react'
-import StyledLayout from '../components/StyledLayout'
+import { graphql } from 'gatsby';
+import PropTypes from 'prop-types';
+import React from 'react';
+import StyledLayout from '../components/StyledLayout';
 
 const Tags = ({ pageContext, data, location }) => {
-  const { tag } = pageContext
-  const { edges, totalCount } = data.allMarkdownRemark
-  const tagHeader = `共 ${totalCount} 篇文章被打上了 <code>${tag}</code> 标签：`
+  const { tag } = pageContext;
+  const { edges, totalCount } = data.allMarkdownRemark;
+  const tagHeader = `共 ${totalCount} 篇文章被打上了 <code>${tag}</code> 标签：`;
 
   return (
     <StyledLayout location={location} noMeta={true} title={`标签页 - ${tag}`}>
@@ -21,8 +21,8 @@ const Tags = ({ pageContext, data, location }) => {
         </Typography>
         <List>
           {edges.map(({ node }) => {
-            const { slug } = node.fields
-            const { title } = node.frontmatter
+            const { slug } = node.fields;
+            const { title } = node.frontmatter;
             return (
               <ListItem button divider component="a" href={slug} key={slug}>
                 <ListItemIcon>
@@ -30,7 +30,7 @@ const Tags = ({ pageContext, data, location }) => {
                 </ListItemIcon>
                 <ListItemText primary={title}/>
               </ListItem>
-            )
+            );
           })}
         </List>
         <Button
@@ -42,8 +42,8 @@ const Tags = ({ pageContext, data, location }) => {
         </Button>
       </div>
     </StyledLayout>
-  )
-}
+  );
+};
 
 Tags.propTypes = {
   pageContext: PropTypes.shape({
@@ -66,9 +66,9 @@ Tags.propTypes = {
       ),
     }),
   }),
-}
+};
 
-export default Tags
+export default Tags;
 
 export const pageQuery = graphql`
   query($tag: String) {
@@ -90,4 +90,4 @@ export const pageQuery = graphql`
       }
     }
   }
-`
+`;

--- a/gatsby-theme-oi-wiki/src/theme/global.ts
+++ b/gatsby-theme-oi-wiki/src/theme/global.ts
@@ -1,4 +1,4 @@
-import { withStyles } from '@material-ui/core/styles'
+import { withStyles } from '@material-ui/core/styles';
 
 const globalStyles = withStyles((theme) => ({
   '@global': {
@@ -58,6 +58,6 @@ const globalStyles = withStyles((theme) => ({
       fontFamily: 'var(--code-block-font)',
     },
   },
-}))
+}));
 
-export default globalStyles
+export default globalStyles;

--- a/gatsby-theme-oi-wiki/src/theme/hightlight-themes/darkplus.ts
+++ b/gatsby-theme-oi-wiki/src/theme/hightlight-themes/darkplus.ts
@@ -10,4 +10,4 @@ export default {
   '--shiki-token-string-expression': '#d16969',
   '--shiki-token-punctuation': '#D4D4D4',
   '--shiki-token-link': '#D4D4D4',
-}
+};

--- a/gatsby-theme-oi-wiki/src/theme/hightlight-themes/lightplus.ts
+++ b/gatsby-theme-oi-wiki/src/theme/hightlight-themes/lightplus.ts
@@ -10,4 +10,4 @@ export default {
   '--shiki-token-string-expression': '#800000',
   '--shiki-token-punctuation': '#000000',
   '--shiki-token-link': '#000000',
-}
+};

--- a/gatsby-theme-oi-wiki/src/theme/index.ts
+++ b/gatsby-theme-oi-wiki/src/theme/index.ts
@@ -1,17 +1,17 @@
-import createPalette, { Palette, PaletteColor } from '@material-ui/core/styles/createPalette'
-import blue from '@material-ui/core/colors/blue'
-import grey from '@material-ui/core/colors/grey'
-import red from '@material-ui/core/colors/red'
-import { createTheme, hexToRgb, ThemeOptions, withStyles } from '@material-ui/core/styles'
+import createPalette, { Palette, PaletteColor } from '@material-ui/core/styles/createPalette';
+import blue from '@material-ui/core/colors/blue';
+import grey from '@material-ui/core/colors/grey';
+import red from '@material-ui/core/colors/red';
+import { createTheme, hexToRgb, ThemeOptions, withStyles } from '@material-ui/core/styles';
 
-import globalStyles from './global'
+import globalStyles from './global';
 
-import paletteColors from '../styles/colors'
-import { Nullable, StrIndexObj } from '../types/common'
-import { noopNull } from '../utils/common'
+import paletteColors from '../styles/colors';
+import { Nullable, StrIndexObj } from '../types/common';
+import { noopNull } from '../utils/common';
 
-import DarkPlus from './hightlight-themes/darkplus'
-import LightPlus from './hightlight-themes/lightplus'
+import DarkPlus from './hightlight-themes/darkplus';
+import LightPlus from './hightlight-themes/lightplus';
 
 type DStrIndexObj = StrIndexObj<StrIndexObj>
 type HexToRGBAParamType = (color?: string, alpha?: number) => string | null
@@ -20,62 +20,62 @@ type ApplyAdaptiveType = (...keys: (keyof Palette)[]) => DStrIndexObj
 type WithStylesReturnType = ReturnType<typeof withStyles>
 type GetThemeCSSElType = (style: WithStylesReturnType) => ReturnType<WithStylesReturnType>
 
-const RGBA_EXPR = /^rgba\((.*)\)$/
-const RGB_EXPR = /^rgb\((.*)\)$/
-const HEX_EXPR = /^#([A-Fa-f0-9]{3}){1,2}$/
+const RGBA_EXPR = /^rgba\((.*)\)$/;
+const RGB_EXPR = /^rgb\((.*)\)$/;
+const HEX_EXPR = /^#([A-Fa-f0-9]{3}){1,2}$/;
 const hexToRGBAParam: HexToRGBAParamType = (color, alpha = 1) => {
   if (color) {
-    let res
-    if (color === 'auto') return color
+    let res;
+    if (color === 'auto') return color;
     else if ((res = color.match(RGBA_EXPR)) !== null) {
-      return res[1]
+      return res[1];
     } else if ((res = color.match(RGB_EXPR)) !== null) {
-      return `${res[1]}, ${alpha}`
+      return `${res[1]}, ${alpha}`;
     } else if (HEX_EXPR.test(color)) {
-      return `${hexToRgb(color).trim().match(RGB_EXPR)?.[1]}, ${alpha}`
-    } else throw new Error('Bad Hex ' + color)
-  } else return null
-}
+      return `${hexToRgb(color).trim().match(RGB_EXPR)?.[1]}, ${alpha}`;
+    } else throw new Error('Bad Hex ' + color);
+  } else return null;
+};
 
 const applyDefaults: ApplyDefaultsType = (theme, ...keys) => {
-  const exp = /^(#|rgba)/
-  const keyObj: ReturnType<ApplyDefaultsType> = {}
+  const exp = /^(#|rgba)/;
+  const keyObj: ReturnType<ApplyDefaultsType> = {};
   keys.forEach(k => {
-    const colorKind = theme[k as keyof Palette]
+    const colorKind = theme[k as keyof Palette];
     Object.keys(colorKind).forEach(el => {
-      const hex = (colorKind as PaletteColor)[el as keyof PaletteColor]
+      const hex = (colorKind as PaletteColor)[el as keyof PaletteColor];
       if (exp.test(hex)) {
-        keyObj[`--${k}-${el}`] = hexToRGBAParam(hex.toString())
+        keyObj[`--${k}-${el}`] = hexToRGBAParam(hex.toString());
       }
-    })
-  })
+    });
+  });
 
-  return keyObj
-}
+  return keyObj;
+};
 
 const applyAdaptive: ApplyAdaptiveType = (...keys) => {
-  const exp = /^(#|rgba)/
-  const rst: ReturnType<ApplyAdaptiveType> = {}
+  const exp = /^(#|rgba)/;
+  const rst: ReturnType<ApplyAdaptiveType> = {};
   keys.forEach(k => {
-    const obj: StrIndexObj = {}
-    const colorKind = lightColor[k]
+    const obj: StrIndexObj = {};
+    const colorKind = lightColor[k];
     Object.keys(colorKind).forEach(el => {
-      const color = (colorKind as PaletteColor)[el as keyof PaletteColor]
-      obj[el] = exp.test(color) ? `rgba(var(--${k}-${el}))` : color
-    })
-    rst[k] = obj
-  })
+      const color = (colorKind as PaletteColor)[el as keyof PaletteColor];
+      obj[el] = exp.test(color) ? `rgba(var(--${k}-${el}))` : color;
+    });
+    rst[k] = obj;
+  });
 
-  return rst
-}
+  return rst;
+};
 
-const getThemeCssEl: GetThemeCSSElType = (style) => style(noopNull)
+const getThemeCssEl: GetThemeCSSElType = (style) => style(noopNull);
 
-export const CustomCssBaseline = globalStyles(noopNull as any)
+export const CustomCssBaseline = globalStyles(noopNull as any);
 
-const lightColor = createPalette({ type: 'light' })
-const darkColor = createPalette({ type: 'dark' })
-const paletteKeys: (keyof Palette)[] = ['primary', 'secondary', 'text', 'background', 'action', 'error', 'warning', 'info', 'success']
+const lightColor = createPalette({ type: 'light' });
+const darkColor = createPalette({ type: 'dark' });
+const paletteKeys: (keyof Palette)[] = ['primary', 'secondary', 'text', 'background', 'action', 'error', 'warning', 'info', 'success'];
 
 const lightCss = {
   '@global': {
@@ -106,7 +106,7 @@ const lightCss = {
       ...applyDefaults(lightColor, ...paletteKeys),
     },
   },
-}
+};
 
 const darkCss = {
   '@global': {
@@ -137,10 +137,10 @@ const darkCss = {
       ...applyDefaults(darkColor, ...paletteKeys),
     },
   },
-}
+};
 
-const LightCssBaseline = getThemeCssEl(withStyles(() => lightCss))
-const DarkCssBaseline = getThemeCssEl(withStyles(() => darkCss))
+const LightCssBaseline = getThemeCssEl(withStyles(() => lightCss));
+const DarkCssBaseline = getThemeCssEl(withStyles(() => darkCss));
 const AutoCssBaseline = getThemeCssEl(withStyles(() => ({
   '@global': {
     'html[data-theme=auto]': lightCss['@global']['html[data-theme=light]'],
@@ -148,7 +148,7 @@ const AutoCssBaseline = getThemeCssEl(withStyles(() => ({
       'html[data-theme=auto]': darkCss['@global']['html[data-theme=dark]'],
     },
   },
-})))
+})));
 
 const SecondaryColorCssBaseline = getThemeCssEl(withStyles(() =>
   paletteColors.reduce((obj, c) => {
@@ -158,10 +158,10 @@ const SecondaryColorCssBaseline = getThemeCssEl(withStyles(() =>
         '--secondary-dark': hexToRGBAParam(c.dark),
         '--secondary-main': hexToRGBAParam(c.main),
         '--secondary-contrast-text': hexToRGBAParam(c.contrastText),
-      }
+      };
     }
-    return obj
-  }, { '@global': {} as StrIndexObj<any> })))
+    return obj;
+  }, { '@global': {} as StrIndexObj<any> })));
 
 const adaptiveTheme = createTheme({
   palette: {
@@ -234,6 +234,6 @@ const adaptiveTheme = createTheme({
   typography: {
     fontFamily: '-apple-system,BlinkMacSystemFont,Segoe UI,Roboto,Oxygen,Ubuntu,Cantarell,Fira Sans,Droid Sans,Helvetica Neue,sans-serif',
   },
-} as ThemeOptions)
+} as ThemeOptions);
 
-export { adaptiveTheme, LightCssBaseline, DarkCssBaseline, AutoCssBaseline, SecondaryColorCssBaseline }
+export { adaptiveTheme, LightCssBaseline, DarkCssBaseline, AutoCssBaseline, SecondaryColorCssBaseline };

--- a/gatsby-theme-oi-wiki/src/types/common.ts
+++ b/gatsby-theme-oi-wiki/src/types/common.ts
@@ -1,4 +1,4 @@
-import React from 'react'
+import React from 'react';
 
 export type Nullable<T> = T | null
 export type StrIndexObj<T = string> = { [k: string]: T }

--- a/gatsby-theme-oi-wiki/src/utils/common.ts
+++ b/gatsby-theme-oi-wiki/src/utils/common.ts
@@ -1,12 +1,12 @@
-import pick from 'lodash/pick'
-import omit from 'lodash/omit'
-import throttle from 'lodash/throttle'
-import uniq from 'lodash/uniq'
+import pick from 'lodash/pick';
+import omit from 'lodash/omit';
+import throttle from 'lodash/throttle';
+import uniq from 'lodash/uniq';
 
 export type NoopNull = (() => null)
 
-export const noopNull: NoopNull = () => null
+export const noopNull: NoopNull = () => null;
 
 // 导出以统一项目内命名
 // FIXME: 存在无法准确推断 paths 的问题，暂未找到合适的方式实现（本意是处理这个问题的）
-export { pick, omit, throttle, uniq }
+export { pick, omit, throttle, uniq };


### PR DESCRIPTION
即使 JavaScript 有 ASI（Automatic Semicolon Insertion）的特性，可以在大部分情况下自动在行尾加入分号的语义，但仍然推荐在编写 JavaScript 代码时手动加入分号。

举一个依赖 ASI 时会遇到问题的场景：

```javascript
// wrong:
const a = foo()
[a, b, c].map(x => {})
// interpreted as: `const a = foo()[a, b, c].map(x => {})`

// possible fix:
const a = foo()
;[a, b, c].map(x => {})

// recommended
const a = foo();
[a, b, c].map(x => {});
```

所以应当通过 ESLint 来规范对于分号的使用。